### PR TITLE
Remove chef client at end of build

### DIFF
--- a/src/w/packer/provisioners/chef/scripts/cleanup.ps1
+++ b/src/w/packer/provisioners/chef/scripts/cleanup.ps1
@@ -1,2 +1,6 @@
 Write-Host "Clean up"
 Remove-Item -Recurse -Force C:/Windows/Temp/chef
+
+# Remove chef client, or it will cause problems later when kitchen tries to install cinc.
+$chef_client = Get-WmiObject -Class Win32_Product | Where-Object{$_.Name.StartsWith("Chef Infra")}
+$chef_client.Uninstall()


### PR DESCRIPTION
The Chef client's presence in the Windows box prevents kitchen from installing Cinc. Windows will throw an MSI-related error causing kitchen to bail. This PR simply uninstalls `Chef Infra*` after provisioning, during the cleanup phase.