### PR TITLE
Update for 2607 - Core

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -2,7 +2,7 @@ var configuration = Argument("configuration", string.Empty);
 var target = Argument("target", "default");
 
 var author = Argument("author", "gusztavvargadr");
-var version = Argument("version", "2601");
+var version = Argument("version", "2607");
 
 var configurationParts = configuration.Split('/', StringSplitOptions.RemoveEmptyEntries);
 var sample = configurationParts.ElementAtOrDefault(0) ?? Argument<string>("sample");

--- a/src/ubuntu/build.vagrant.pkr.hcl
+++ b/src/ubuntu/build.vagrant.pkr.hcl
@@ -1,7 +1,7 @@
 packer {
   required_plugins {
     vagrant = {
-      version = "~> 1.1.6"
+      version = "~> 1.1"
       source  = "github.com/hashicorp/vagrant"
     }
   }

--- a/src/ubuntu/chef/initialize.sh
+++ b/src/ubuntu/chef/initialize.sh
@@ -10,7 +10,7 @@ sudo apt-get install -y curl
 mkdir -p /var/tmp/packer-build/chef
 
 if ! [ -x "$(command -v chef-client)" ]; then
-  curl -Ls https://omnitruck.chef.io/install.sh | sudo bash -s -- -P chef -v 18.8.11
+  curl -Ls https://omnitruck.chef.io/install.sh | sudo bash -s -- -P chef -v 18.10.17
 fi
 chef-client --version
 

--- a/src/ubuntu/core.pkr.hcl
+++ b/src/ubuntu/core.pkr.hcl
@@ -1,5 +1,5 @@
 packer {
-  required_version = "~> 1.14.2"
+  required_version = "~> 1.14"
 }
 
 variable "author" {

--- a/src/ubuntu/core.pkr.hcl
+++ b/src/ubuntu/core.pkr.hcl
@@ -1,5 +1,5 @@
 packer {
-  required_version = "~> 1.14"
+  required_version = "~> 1.15"
 }
 
 variable "author" {

--- a/src/ubuntu/source.amazon-ebs.pkr.hcl
+++ b/src/ubuntu/source.amazon-ebs.pkr.hcl
@@ -1,7 +1,7 @@
 packer {
   required_plugins {
     amazon = {
-      version = "~> 1.8.0"
+      version = "~> 1.8"
       source  = "github.com/hashicorp/amazon"
     }
   }

--- a/src/ubuntu/source.hyperv.pkr.hcl
+++ b/src/ubuntu/source.hyperv.pkr.hcl
@@ -1,7 +1,7 @@
 packer {
   required_plugins {
     hyperv = {
-      version = "~> 1.1.5"
+      version = "~> 1.1"
       source  = "github.com/hashicorp/hyperv"
     }
   }

--- a/src/ubuntu/source.qemu.pkr.hcl
+++ b/src/ubuntu/source.qemu.pkr.hcl
@@ -1,7 +1,7 @@
 packer {
   required_plugins {
     qemu = {
-      version = "~> 1.1.4"
+      version = "~> 1.1"
       source  = "github.com/hashicorp/qemu"
     }
   }

--- a/src/ubuntu/source.virtualbox.pkr.hcl
+++ b/src/ubuntu/source.virtualbox.pkr.hcl
@@ -1,7 +1,7 @@
 packer {
   required_plugins {
     virtualbox = {
-      version = "~> 1.1.3"
+      version = "~> 1.1"
       source  = "github.com/hashicorp/virtualbox"
     }
   }

--- a/src/ubuntu/source.vmware.pkr.hcl
+++ b/src/ubuntu/source.vmware.pkr.hcl
@@ -1,7 +1,7 @@
 packer {
   required_plugins {
     vmware = {
-      version = "~> 1.2.0"
+      version = "~> 1.2"
       source  = "github.com/hashicorp/vmware"
     }
   }

--- a/src/windows/boot/autounattend-first-logon.ps1
+++ b/src/windows/boot/autounattend-first-logon.ps1
@@ -3,7 +3,7 @@ $ProgressPreference = 'SilentlyContinue'
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
 Write-Host "Install Chocolatey"
-%{ for chocolatey_version in compact([lookup(boot, "boot_chocolatey_version", "2.6.0")]) ~}
+%{ for chocolatey_version in compact([lookup(boot, "boot_chocolatey_version", "2.7.3")]) ~}
 $env:chocolateyVersion = '${chocolatey_version}'
 %{ endfor ~}
 Set-ExecutionPolicy Bypass -Scope Process -Force; Invoke-WebRequest https://chocolatey.org/install.ps1 -UseBasicParsing | Invoke-Expression

--- a/src/windows/build.vagrant.pkr.hcl
+++ b/src/windows/build.vagrant.pkr.hcl
@@ -1,7 +1,7 @@
 packer {
   required_plugins {
     vagrant = {
-      version = "~> 1.1.6"
+      version = "~> 1.1"
       source  = "github.com/hashicorp/vagrant"
     }
   }

--- a/src/windows/chef/cookbooks/gusztavvargadr_packer_windows/recipes/initialize.rb
+++ b/src/windows/chef/cookbooks/gusztavvargadr_packer_windows/recipes/initialize.rb
@@ -120,7 +120,7 @@ if vmware?
   vmware_version = (powershell_out('& "C:/Program Files/VMware/VMware Tools/VMwareToolboxCmd.exe" -v').stdout rescue '').strip
 
   unless vmware_version.include?('13.')
-    vmware_tools_source = 'https://packages-prod.broadcom.com/tools/releases/13.0.10/x64/VMware-tools-13.0.10-25056151-x64.exe'
+    vmware_tools_source = 'https://packages-prod.broadcom.com/tools/releases/13.1.0/windows/x64/VMware-tools-13.1.0-25218885-x64.exe'
     vmware_tools_target = "#{Chef::Config['file_cache_path']}/VMware-tools.exe"
 
     remote_file vmware_tools_target do

--- a/src/windows/chef/initialize.ps1
+++ b/src/windows/chef/initialize.ps1
@@ -4,7 +4,7 @@ $ProgressPreference = 'SilentlyContinue'
 mkdir -Force C:/Windows/Temp/chef
 
 If ((Get-Command "C:/opscode/chef/bin/chef-client.bat" -ErrorAction Ignore).Count -eq 0) {
-  . { iwr -useb https://omnitruck.chef.io/install.ps1 } | iex; install -project chef -version 18.8.11
+  . { iwr -useb https://omnitruck.chef.io/install.ps1 } | iex; install -project chef -version 18.10.17
 }
 C:/opscode/chef/bin/chef-client.bat --version
 

--- a/src/windows/core.pkr.hcl
+++ b/src/windows/core.pkr.hcl
@@ -1,5 +1,5 @@
 packer {
-  required_version = "~> 1.14.2"
+  required_version = "~> 1.14"
 }
 
 variable "author" {

--- a/src/windows/core.pkr.hcl
+++ b/src/windows/core.pkr.hcl
@@ -1,5 +1,5 @@
 packer {
-  required_version = "~> 1.14"
+  required_version = "~> 1.15"
 }
 
 variable "author" {

--- a/src/windows/source.amazon-ebs.pkr.hcl
+++ b/src/windows/source.amazon-ebs.pkr.hcl
@@ -1,7 +1,7 @@
 packer {
   required_plugins {
     amazon = {
-      version = "~> 1.8.0"
+      version = "~> 1.8"
       source  = "github.com/hashicorp/amazon"
     }
   }

--- a/src/windows/source.hyperv.pkr.hcl
+++ b/src/windows/source.hyperv.pkr.hcl
@@ -1,7 +1,7 @@
 packer {
   required_plugins {
     hyperv = {
-      version = "~> 1.1.5"
+      version = "~> 1.1"
       source  = "github.com/hashicorp/hyperv"
     }
   }

--- a/src/windows/source.qemu.pkr.hcl
+++ b/src/windows/source.qemu.pkr.hcl
@@ -1,7 +1,7 @@
 packer {
   required_plugins {
     qemu = {
-      version = "~> 1.1.4"
+      version = "~> 1.1"
       source  = "github.com/hashicorp/qemu"
     }
   }

--- a/src/windows/source.virtualbox.pkr.hcl
+++ b/src/windows/source.virtualbox.pkr.hcl
@@ -1,7 +1,7 @@
 packer {
   required_plugins {
     virtualbox = {
-      version = "~> 1.1.3"
+      version = "~> 1.1"
       source  = "github.com/hashicorp/virtualbox"
     }
   }

--- a/src/windows/source.vmware.pkr.hcl
+++ b/src/windows/source.vmware.pkr.hcl
@@ -1,7 +1,7 @@
 packer {
   required_plugins {
     vmware = {
-      version = "~> 1.2.0"
+      version = "~> 1.2"
       source  = "github.com/hashicorp/vmware"
     }
   }


### PR DESCRIPTION
## Summary

This pull request updates dependencies and software versions across both Ubuntu and Windows build scripts and configuration files to ensure compatibility with newer releases and improve system consistency. The changes include bumping Packer and plugin version constraints, updating Chef and Chocolatey installation scripts to use newer versions, and upgrading the VMware Tools installer.

### Relationships

- Related to #518

## Details

**Dependency and Plugin Updates:**
- Updated Packer core version constraints to `~> 1.15` in both `src/ubuntu/core.pkr.hcl` and `src/windows/core.pkr.hcl` for improved compatibility with newer Packer features.
- Relaxed version constraints for all major Packer plugins (`amazon`, `hyperv`, `qemu`, `virtualbox`, `vmware`, `vagrant`) to allow any `1.1.x` or `1.2.x` version, reducing the need for frequent updates. [[1]](diffhunk://#diff-6b21c0d1d77104ce1af3073d77b2ceda332ab938beb3430a0b7e8fafc210109dL4-R4) [[2]](diffhunk://#diff-7504646e25c119542f1539465e507b45a881e547361ff4b3540fccda75e3e2e9L4-R4) [[3]](diffhunk://#diff-09197b07ba7840d6619b4794920a6d6ca82b0040493fa60708728db0e46d0af0L4-R4) [[4]](diffhunk://#diff-2777edb0839cc033223124b4dc5cd50f111b1dc6d8aaa02a36306afd74fc67e4L4-R4) [[5]](diffhunk://#diff-aef05204dab9d181ceff5d5d72647cdf1c31360a114d2cfe8b48f2fd4ebe6110L4-R4) [[6]](diffhunk://#diff-6d1c0488237424f1a5b6ee7e4bd233fac303571b5585d72754338d46e6144457L4-R4) [[7]](diffhunk://#diff-dab92d56e4fe2f12ffbaef57f1d0d69d9ede7cc55867b6aade2dc2b7d38c05d0L4-R4) [[8]](diffhunk://#diff-df8f8f79820a70911ac7935ab02eab87ede9f295b05811d2552aacba67ffe723L4-R4) [[9]](diffhunk://#diff-34f0bfcdf962c649d6b087e9fb002a5ff14909d0d73fca0c3930792f3b9e1138L4-R4) [[10]](diffhunk://#diff-d0843868dd73dc082170ee16265b0acc25e07f8914c4e4208f08c20922ff6399L4-R4) [[11]](diffhunk://#diff-d6562f4f509fe19c08f5dc7a55202cba9854e50c6771b3382dc0bd1fcf41bce8L4-R4)

**Chef and Chocolatey Version Upgrades:**
- Updated Chef installation scripts to use version `18.10.17` instead of `18.8.11` on both Ubuntu (`src/ubuntu/chef/initialize.sh`) and Windows (`src/windows/chef/initialize.ps1`). [[1]](diffhunk://#diff-19a19fd15561cc689126a26ab76ff975afbac697e8254ca211b057264bb45ed6L13-R13) [[2]](diffhunk://#diff-d5dd082940f6b497064874eb4b05c46d304f1d8d32a0bc37408d00eda8632aeeL7-R7)
- Changed the default Chocolatey version installed during Windows bootstrapping from `2.6.0` to `2.7.3` for the latest features and fixes.

**VMware Tools Update:**
- Upgraded the VMware Tools installer used in Windows builds from version `13.0.10` to `13.1.0` for better compatibility and bug fixes.

**Other Updates:**
- Updated the `chef` submodule to a newer commit, pulling in the latest changes from its repository.
- Incremented the build script version from `2601` to `2607` in `build.cake`.