### PR TITLE
Update for 2607 - Components - Ubuntu

### DIFF
--- a/samples/ubuntu-desktop/images.pkrvars.hcl
+++ b/samples/ubuntu-desktop/images.pkrvars.hcl
@@ -5,9 +5,9 @@ images = {
     }
 
     native = {
-      source_iso_url_local  = "ubuntu-24.04.3-desktop-amd64.iso"
-      source_iso_url_remote = "https://releases.ubuntu.com/24.04/ubuntu-24.04.3-desktop-amd64.iso"
-      source_iso_checksum   = "sha256:faabcf33ae53976d2b8207a001ff32f4e5daae013505ac7188c9ea63988f8328"
+      source_iso_url_local  = "ubuntu-24.04.4-desktop-amd64.iso"
+      source_iso_url_remote = "https://releases.ubuntu.com/24.04/ubuntu-24.04.4-desktop-amd64.iso"
+      source_iso_checksum   = "sha256:3a4c9877b483ab46d7c3fbe165a0db275e1ae3cfe56a5657e5a47c2f99a99d1e"
 
       chef_attributes = "ubuntu"
     }

--- a/samples/ubuntu-server/images.pkrvars.hcl
+++ b/samples/ubuntu-server/images.pkrvars.hcl
@@ -5,9 +5,9 @@ images = {
     }
 
     native = {
-      source_iso_url_local  = "ubuntu-24.04.3-live-server-amd64.iso"
-      source_iso_url_remote = "https://releases.ubuntu.com/24.04/ubuntu-24.04.3-live-server-amd64.iso"
-      source_iso_checksum   = "sha256:c3514bf0056180d09376462a7a1b4f213c1d6e8ea67fae5c25099c6fd3d8274b"
+      source_iso_url_local  = "ubuntu-24.04.4-live-server-amd64.iso"
+      source_iso_url_remote = "https://releases.ubuntu.com/24.04/ubuntu-24.04.4-live-server-amd64.iso"
+      source_iso_checksum   = "sha256:e907d92eeec9df64163a7e454cbc8d7755e8ddc7ed42f99dbc80c40f1a138433"
     }
 
     vagrant = {


### PR DESCRIPTION
## Summary

This pull request updates the Ubuntu ISO versions used for building desktop and server images to the latest 24.04.4 release. The changes ensure that both the desktop and server image builds use the most recent official Ubuntu releases and their corresponding checksums.

### Relationsips

- Related to #518

## Details

**Ubuntu ISO version updates:**

* Updated the `source_iso_url_local`, `source_iso_url_remote`, and `source_iso_checksum` fields for the desktop image in `samples/ubuntu-desktop/images.pkrvars.hcl` to use Ubuntu 24.04.4.
* Updated the `source_iso_url_local`, `source_iso_url_remote`, and `source_iso_checksum` fields for the server image in `samples/ubuntu-server/images.pkrvars.hcl` to use Ubuntu 24.04.4.
