### PR TITLE
Install OpenSSH as Windows Capability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Valid providers include `virtualbox`, `vmware`, `hyperv`, and `qemu`; builds req
 
 ## Coding Style & Naming Conventions
 
-Run `packer fmt` for HCL. Use two-space indentation in Ruby, YAML, and Cake files, and follow existing PowerShell and shell conventions. Ruby style is governed by `.rubocop.yml`; generated and vendored `lib/` content is excluded. Preserve repository line endings: LF for shell scripts and CRLF for PowerShell. Use lowercase, hyphenated sample and image-variant directories (for example, `ubuntu-server` and `25h2-enterprise`), and keep provider-specific files named consistently, such as `source.virtualbox.pkr.hcl`.
+Run `packer fmt` for HCL. Use two-space indentation in Ruby, YAML, and Cake files, and follow existing PowerShell and shell conventions. Ruby style is governed by `.rubocop.yml`; generated and vendored `lib/` content is excluded. Do not hard-wrap prose in Markdown files or GitHub issue and pull request content; keep each paragraph or list item on one source line and let the renderer wrap it. Preserve repository line endings: LF for shell scripts and CRLF for PowerShell. Use lowercase, hyphenated sample and image-variant directories (for example, `ubuntu-server` and `25h2-enterprise`), and keep provider-specific files named consistently, such as `source.virtualbox.pkr.hcl`.
 
 ## Testing Guidelines
 

--- a/src/windows/boot/autounattend-first-logon.ps1
+++ b/src/windows/boot/autounattend-first-logon.ps1
@@ -10,9 +10,11 @@ Set-ExecutionPolicy Bypass -Scope Process -Force; Invoke-WebRequest https://choc
 
 Write-Host "Install OpenSSH"
 netsh advfirewall firewall add rule name="OpenSSH-Install" dir=in localport=22 protocol=TCP action=block
-choco install openssh -y --version 8.0.0.1 -params '"/SSHServerFeature"' # /PathSpecsToProbeForShellEXEString:$env:windir\system32\windowspowershell\v1.0\powershell.exe"'
+$open_ssh_server = Get-WindowsCapability -Online | Where-Object Name -Like "OpenSSH.Server*"
+if ($open_ssh_server.State -ne "Installed") {
+  Add-WindowsCapability -Online -Name $open_ssh_server.Name
+}
 net stop sshd
-netsh advfirewall firewall delete rule name="OpenSSH-Install"
 
 Write-Host "Configure OpenSSH"
 net start sshd
@@ -21,6 +23,7 @@ netsh advfirewall firewall add rule name="OpenSSH-Packer" dir=in localport=22 pr
 $sshd_config = "$($env:ProgramData)\ssh\sshd_config"
 (Get-Content $sshd_config).Replace("Match Group administrators", "# Match Group administrators") | Set-Content $sshd_config
 (Get-Content $sshd_config).Replace("AuthorizedKeysFile", "# AuthorizedKeysFile") | Set-Content $sshd_config
+netsh advfirewall firewall delete rule name="OpenSSH-Install"
 
 Write-Host "Install WinRM"
 netsh advfirewall firewall add rule name="WinRM-Install" dir=in localport=5985 protocol=TCP action=block

--- a/src/windows/vagrant/cleanup.ps1
+++ b/src/windows/vagrant/cleanup.ps1
@@ -1,2 +1,3 @@
 Get-AppxPackage -Name "*BingSearch*" | Remove-AppxPackage
 Get-AppxPackage -Name "*GameAssist*" | Remove-AppxPackage
+Get-AppxPackage -Name "*MicrosoftEdge*" | Remove-AppxPackage


### PR DESCRIPTION
## Summary

- Install OpenSSH Server through Windows capability servicing instead of a pinned Chocolatey package.
- Discover the capability identity exposed by the running Windows image and skip installation when it is already installed.
- Keep the temporary SSH firewall block active until the existing SSH configuration is complete.
- Document the repository convention not to hard-wrap Markdown and GitHub prose.

### Relationships

- Related to #517

## Why

The Windows Server 2022 image currently has a package-managed `sshd` service while Windows reports the OpenSSH Server capability as absent. Software that manages OpenSSH through Windows capability servicing can therefore conflict with the package installation. Using the native capability keeps Windows servicing state consistent and remains safe on Windows Server 2025, where OpenSSH is already present.

## Validation

- `packer fmt -check src`
- `dotnet cake --configuration windows-server/2022-standard/virtualbox/native --target init`
- Two-axis code review: no standards or specification findings
- Full Windows Server 2022 and Windows 11 image builds will be validated separately on a machine with the required virtualization stack
