### PR TITLE
Publish Windows Vagrant Boxes Through Cloudflare R2

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -51,6 +51,16 @@ A versioned, provider-specific distribution package produced from a native image
 and consumable by Vagrant.
 _Avoid_: native image
 
+**Box artifact origin**:
+The durable public location from which consumers download a Vagrant box.
+
+**Vagrant registry entry**:
+The catalog metadata for a Vagrant box, including its release version, provider, architecture, checksum, and box artifact origin.
+
+**Alias box**:
+A Vagrant registry entry with a stable consumer-facing name whose box artifact origin references another registry entry for the same release version, provider, and architecture.
+_Avoid_: duplicate box
+
 **Build configuration**:
 The complete selection of an image family, image variant, provider, and image
 artifact type.

--- a/docs/adr/0002-store-windows-vagrant-boxes-in-cloudflare-r2.md
+++ b/docs/adr/0002-store-windows-vagrant-boxes-in-cloudflare-r2.md
@@ -1,0 +1,15 @@
+---
+status: accepted
+---
+
+# Store Windows Vagrant boxes in Cloudflare R2
+
+Windows Vagrant boxes use Cloudflare R2 as their box artifact origin while HCP Vagrant Registry remains the catalog for release versions, providers, architectures, external download URLs, and SHA-256 checksums. This applies to every newly published Windows box regardless of size and remains the default even if direct uploads larger than 5 GiB become reliable again; Ubuntu boxes continue to use HCP-hosted artifacts.
+
+R2 objects use `<canonical-box-name>/<release-version>/<vagrant-provider>/<architecture>/vagrant.box`. Publication copies only `vagrant.box` through the configured rclone destination, treats existing object keys as immutable, and has no direct-HCP fallback. Successful uploads may remain if later registry publication fails, no historical versions are migrated, and retention is deferred.
+
+The rclone destination and public box origin are configurable, initially defaulting to `r2:packer` and the existing `r2.dev` endpoint. Moving production downloads to a custom domain is tracked by [#524](https://github.com/gusztavvargadr/packer/issues/524).
+
+Alias boxes on both Windows and Ubuntu reference their canonical registry entries through the readable `vagrantcloud.com` download URL rather than storing duplicate artifacts.
+
+Implementation is tracked by [#525](https://github.com/gusztavvargadr/packer/issues/525).

--- a/src/ubuntu/build.vagrant.pkr.hcl
+++ b/src/ubuntu/build.vagrant.pkr.hcl
@@ -162,7 +162,7 @@ build {
       post-processor "vagrant-registry" {
         box_tag              = "${local.image_author}/${post-processors.value}"
         version              = local.image_version
-        box_download_url     = "https://api.hashicorp.cloud/vagrant/2022-08-01/${local.image_author}/boxes/${lookup(local.vagrant_options, "box_name", replace(local.image_name, "/", "-"))}/versions/${local.image_version}/providers/${lookup(local.vagrant_providers, local.image_provider, "")}/${local.vagrant_options.architecture}/vagrant.box"
+        box_download_url     = "https://vagrantcloud.com/${local.image_author}/boxes/${lookup(local.vagrant_options, "box_name", replace(local.image_name, "/", "-"))}/versions/${local.image_version}/providers/${lookup(local.vagrant_providers, local.image_provider, "")}/${local.vagrant_options.architecture}/vagrant.box"
         box_checksum         = "SHA256:${split("\t", file("${local.artifacts_directory}/checksum.sha256"))[0]}"
         architecture         = local.vagrant_options.architecture
         default_architecture = local.vagrant_options.architecture

--- a/src/windows/build.vagrant.pkr.hcl
+++ b/src/windows/build.vagrant.pkr.hcl
@@ -7,6 +7,18 @@ packer {
   }
 }
 
+variable "box_artifact_destination" {
+  type        = string
+  description = "The rclone destination root for published Vagrant boxes."
+  default     = "r2:packer"
+}
+
+variable "box_artifact_origin" {
+  type        = string
+  description = "The public origin for published Vagrant boxes."
+  default     = "https://pub-8fcabe1edc344cb782c6dafddb0fe446.r2.dev"
+}
+
 locals {
   vagrant_import_sources = {
     virtualbox = "virtualbox-ovf.core"
@@ -32,6 +44,10 @@ locals {
     hyperv     = "hyperv"
     qemu       = "libvirt"
   }
+
+  vagrant_box_name       = lookup(local.vagrant_options, "box_name", replace(local.image_name, "/", "-"))
+  vagrant_box_provider   = lookup(local.vagrant_providers, local.image_provider, "")
+  vagrant_box_object_key = "${local.vagrant_box_name}/${local.image_version}/${local.vagrant_box_provider}/${local.vagrant_options.architecture}/vagrant.box"
 }
 
 locals {
@@ -145,14 +161,21 @@ build {
 
   sources = ["null.core"]
 
+  provisioner "shell-local" {
+    inline = [
+      "rclone copyto \"${local.artifacts_directory}/vagrant/vagrant.box\" \"${var.box_artifact_destination}/${local.vagrant_box_object_key}\" --progress --checksum --immutable",
+    ]
+  }
+
   post-processors {
     post-processor "artifice" {
       files = ["${local.artifacts_directory}/vagrant/vagrant.box"]
     }
 
     post-processor "vagrant-registry" {
-      box_tag              = "${local.image_author}/${lookup(local.vagrant_options, "box_name", replace(local.image_name, "/", "-"))}"
+      box_tag              = "${local.image_author}/${local.vagrant_box_name}"
       version              = local.image_version
+      box_download_url     = "${var.box_artifact_origin}/${local.vagrant_box_object_key}"
       box_checksum         = "SHA256:${split("\t", file("${local.artifacts_directory}/checksum.sha256"))[0]}"
       architecture         = local.vagrant_options.architecture
       default_architecture = local.vagrant_options.architecture

--- a/src/windows/build.vagrant.pkr.hcl
+++ b/src/windows/build.vagrant.pkr.hcl
@@ -20,6 +20,9 @@ variable "box_artifact_origin" {
 }
 
 locals {
+  box_artifact_destination = var.box_artifact_destination
+  box_artifact_origin      = var.box_artifact_origin
+
   vagrant_import_sources = {
     virtualbox = "virtualbox-ovf.core"
     vmware     = "vmware-vmx.core"
@@ -163,7 +166,7 @@ build {
 
   provisioner "shell-local" {
     inline = [
-      "rclone copyto \"${local.artifacts_directory}/vagrant/vagrant.box\" \"${var.box_artifact_destination}/${local.vagrant_box_object_key}\" --progress --checksum --immutable",
+      "rclone copyto \"${local.artifacts_directory}/vagrant/vagrant.box\" \"${local.box_artifact_destination}/${local.vagrant_box_object_key}\" --progress --checksum --immutable",
     ]
   }
 
@@ -175,7 +178,7 @@ build {
     post-processor "vagrant-registry" {
       box_tag              = "${local.image_author}/${local.vagrant_box_name}"
       version              = local.image_version
-      box_download_url     = "${var.box_artifact_origin}/${local.vagrant_box_object_key}"
+      box_download_url     = "${local.box_artifact_origin}/${local.vagrant_box_object_key}"
       box_checksum         = "SHA256:${split("\t", file("${local.artifacts_directory}/checksum.sha256"))[0]}"
       architecture         = local.vagrant_options.architecture
       default_architecture = local.vagrant_options.architecture

--- a/src/windows/build.vagrant.pkr.hcl
+++ b/src/windows/build.vagrant.pkr.hcl
@@ -194,7 +194,7 @@ build {
       post-processor "vagrant-registry" {
         box_tag              = "${local.image_author}/${post-processors.value}"
         version              = local.image_version
-        box_download_url     = "https://api.hashicorp.cloud/vagrant/2022-08-01/${local.image_author}/boxes/${lookup(local.vagrant_options, "box_name", replace(local.image_name, "/", "-"))}/versions/${local.image_version}/providers/${lookup(local.vagrant_providers, local.image_provider, "")}/${local.vagrant_options.architecture}/vagrant.box"
+        box_download_url     = "https://vagrantcloud.com/${local.image_author}/boxes/${lookup(local.vagrant_options, "box_name", replace(local.image_name, "/", "-"))}/versions/${local.image_version}/providers/${lookup(local.vagrant_providers, local.image_provider, "")}/${local.vagrant_options.architecture}/vagrant.box"
         box_checksum         = "SHA256:${split("\t", file("${local.artifacts_directory}/checksum.sha256"))[0]}"
         architecture         = local.vagrant_options.architecture
         default_architecture = local.vagrant_options.architecture


### PR DESCRIPTION
## Summary

- publish newly released Windows Vagrant box payloads to a configurable Cloudflare R2 destination before registering them in HCP Vagrant Registry
- retain HCP as the catalog and checksum authority while using immutable, checksum-aware R2 object paths for the box artifacts
- make Windows and Ubuntu alias boxes reference their canonical registry entries through readable `vagrantcloud.com` URLs without duplicating artifacts
- document the box artifact origin, registry entry, and alias concepts together with the accepted R2 architecture decision

### Relationships

- Closes #525
- Closes #526
- Closes #527

## Why

Direct uploads of Windows boxes larger than 5 GiB to HCP Vagrant Registry fail with HTTP 499 or 504 responses. Using Cloudflare R2 as the Windows box artifact origin removes that release blocker while preserving existing registry discovery, version, provider, architecture, and checksum behavior.

## Impact

New Windows publications use the configured R2 origin and fail before registry publication if the immutable copy fails. Canonical Ubuntu publication and historical releases remain unchanged. Alias names remain stable for consumers while resolving to their canonical artifacts.

## Validation

- `git diff --check`
- `packer fmt -check src`
- the branch is already published to `origin/feature/publish-through-cloudflare-r2-525`; the multi-hour provider build matrix was not rerun while opening this PR
