### PR TITLE
Update for 2607 - Components - Windows

### DIFF
--- a/samples/windows-11/images.pkrvars.hcl
+++ b/samples/windows-11/images.pkrvars.hcl
@@ -84,9 +84,9 @@ images = {
     }
 
     native = {
-      source_iso_url_local  = "Windows11_InsiderPreview_EnterpriseVL_x64_en-us_27924.iso"
-      source_iso_url_remote = "https://api.hashicorp.cloud/vagrant/2022-08-01/gusztavvargadr-iso/boxes/windows-11-insider-preview/versions/2511.0.0/providers/iso/amd64/vagrant.box"
-      source_iso_checksum   = "sha256:c5ab29789cd753ae6d0d63936aeee55537cd061861db697e15fbe688b7720d39"
+      source_iso_url_local  = "Windows11_InsiderPreview_EnterpriseVL_x64_en-us_29617_1000.iso"
+      source_iso_url_remote = ""
+      source_iso_checksum   = "sha256:403213b4a69f03e9bd595cedb57b9a51ac4248f434e71ccf9d445679a7cf92a5"
 
       boot_setup_script = "setup.cmd"
       boot_image_name   = "Windows 11 Enterprise"

--- a/samples/windows-server/images.pkrvars.hcl
+++ b/samples/windows-server/images.pkrvars.hcl
@@ -101,9 +101,9 @@ images = {
     }
 
     native = {
-      source_iso_url_local  = "Windows_InsiderPreview_Server_vNext_en-us_26534.iso"
-      source_iso_url_remote = "https://api.hashicorp.cloud/vagrant/2022-08-01/gusztavvargadr-iso/boxes/windows-server-insider-preview/versions/2511.0.0/providers/iso/amd64/vagrant.box"
-      source_iso_checksum   = "sha256:7dd34745b2837006db8996b09cbd11a750cb9519f6e92b78fe229739a61f59d8"
+      source_iso_url_local  = "Windows_InsiderPreview_Server_vNext_en-us_29621_1000.iso"
+      source_iso_url_remote = ""
+      source_iso_checksum   = "sha256:10c512c45980de5c857f8e2610a40e06513860a10f063c550300994ab9f6d62e"
 
       boot_image_name  = "Windows Server 2025 SERVERSTANDARD"
       boot_product_key = "MFY9F-XBN2F-TYFMP-CCV49-RMYVH"
@@ -124,9 +124,9 @@ images = {
     }
 
     native = {
-      source_iso_url_local  = "Windows_InsiderPreview_Server_vNext_en-us_26534.iso"
-      source_iso_url_remote = "https://api.hashicorp.cloud/vagrant/2022-08-01/gusztavvargadr-iso/boxes/windows-server-insider-preview/versions/2511.0.0/providers/iso/amd64/vagrant.box"
-      source_iso_checksum   = "sha256:7dd34745b2837006db8996b09cbd11a750cb9519f6e92b78fe229739a61f59d8"
+      source_iso_url_local  = "Windows_InsiderPreview_Server_vNext_en-us_29621_1000.iso"
+      source_iso_url_remote = ""
+      source_iso_checksum   = "sha256:10c512c45980de5c857f8e2610a40e06513860a10f063c550300994ab9f6d62e"
 
       boot_image_name  = "Windows Server 2025 SERVERSTANDARDCORE"
       boot_product_key = "MFY9F-XBN2F-TYFMP-CCV49-RMYVH"

--- a/src/windows/build.vagrant.pkr.hcl
+++ b/src/windows/build.vagrant.pkr.hcl
@@ -166,7 +166,7 @@ build {
 
   provisioner "shell-local" {
     inline = [
-      "rclone copyto \"${local.artifacts_directory}/vagrant/vagrant.box\" \"${local.box_artifact_destination}/${local.vagrant_box_object_key}\" --progress --checksum --immutable",
+      "rclone copyto \"${local.artifacts_directory}/vagrant/vagrant.box\" \"${local.box_artifact_destination}/${local.vagrant_box_object_key}\" --verbose --checksum --immutable",
     ]
   }
 


### PR DESCRIPTION
## Summary

This pull request updates the Windows 11 and Windows Server image definitions to use the latest Insider Preview ISOs and improves logging for the Vagrant box upload process.

### Relationships

- Related to #518

**Image Updates:**

* Updated the `native` image definitions in `samples/windows-11/images.pkrvars.hcl` to use `Windows11_InsiderPreview_EnterpriseVL_x64_en-us_29617_1000.iso` with a new checksum and removed the remote ISO URL.
* Updated both `SERVERSTANDARD` and `SERVERSTANDARDCORE` `native` image definitions in `samples/windows-server/images.pkrvars.hcl` to use `Windows_InsiderPreview_Server_vNext_en-us_29621_1000.iso` with a new checksum and removed the remote ISO URL. [[1]](diffhunk://#diff-bb2e33325773b883e8e8148b147036f61a5315aad8fbb486ed0e1241930debe2L104-R106) [[2]](diffhunk://#diff-bb2e33325773b883e8e8148b147036f61a5315aad8fbb486ed0e1241930debe2L127-R129)

**Provisioning Improvements:**

* Changed the Vagrant box upload command in `src/windows/build.vagrant.pkr.hcl` to use `--verbose` instead of `--progress` for more detailed logging during the upload process.
