### PR TITLE
Support ARM64 Windows 11 and Ubuntu images on macOS

### DIFF
--- a/.azure-pipelines/development-ubuntu/2204-arm64/virtualbox.yml
+++ b/.azure-pipelines/development-ubuntu/2204-arm64/virtualbox.yml
@@ -1,0 +1,15 @@
+trigger: none
+pr: none
+
+resources:
+  pipelines:
+    - pipeline: source
+      source: ubuntu-desktop.2204-lts-ubuntu-arm64.virtualbox
+
+stages:
+  - template: ../../stages.yml
+    parameters:
+      sample: development-ubuntu
+      image: 2204-arm64
+      provider: virtualbox
+      hostArchitecture: ARM64

--- a/.azure-pipelines/development-ubuntu/2204-arm64/vmware.yml
+++ b/.azure-pipelines/development-ubuntu/2204-arm64/vmware.yml
@@ -1,0 +1,15 @@
+trigger: none
+pr: none
+
+resources:
+  pipelines:
+    - pipeline: source
+      source: ubuntu-desktop.2204-lts-ubuntu-arm64.vmware
+
+stages:
+  - template: ../../stages.yml
+    parameters:
+      sample: development-ubuntu
+      image: 2204-arm64
+      provider: vmware
+      hostArchitecture: ARM64

--- a/.azure-pipelines/development-ubuntu/2404-arm64/virtualbox.yml
+++ b/.azure-pipelines/development-ubuntu/2404-arm64/virtualbox.yml
@@ -1,0 +1,15 @@
+trigger: none
+pr: none
+
+resources:
+  pipelines:
+    - pipeline: source
+      source: ubuntu-desktop.2404-lts-ubuntu-arm64.virtualbox
+
+stages:
+  - template: ../../stages.yml
+    parameters:
+      sample: development-ubuntu
+      image: 2404-arm64
+      provider: virtualbox
+      hostArchitecture: ARM64

--- a/.azure-pipelines/development-ubuntu/2404-arm64/vmware.yml
+++ b/.azure-pipelines/development-ubuntu/2404-arm64/vmware.yml
@@ -1,0 +1,15 @@
+trigger: none
+pr: none
+
+resources:
+  pipelines:
+    - pipeline: source
+      source: ubuntu-desktop.2404-lts-ubuntu-arm64.vmware
+
+stages:
+  - template: ../../stages.yml
+    parameters:
+      sample: development-ubuntu
+      image: 2404-arm64
+      provider: vmware
+      hostArchitecture: ARM64

--- a/.azure-pipelines/docker-linux/community-ubuntu-server-arm64/virtualbox.yml
+++ b/.azure-pipelines/docker-linux/community-ubuntu-server-arm64/virtualbox.yml
@@ -1,0 +1,15 @@
+trigger: none
+pr: none
+
+resources:
+  pipelines:
+    - pipeline: source
+      source: ubuntu-server.2404-lts-arm64.virtualbox
+
+stages:
+  - template: ../../stages.yml
+    parameters:
+      sample: docker-linux
+      image: community-ubuntu-server-arm64
+      provider: virtualbox
+      hostArchitecture: ARM64

--- a/.azure-pipelines/docker-linux/community-ubuntu-server-arm64/vmware.yml
+++ b/.azure-pipelines/docker-linux/community-ubuntu-server-arm64/vmware.yml
@@ -1,0 +1,15 @@
+trigger: none
+pr: none
+
+resources:
+  pipelines:
+    - pipeline: source
+      source: ubuntu-server.2404-lts-arm64.vmware
+
+stages:
+  - template: ../../stages.yml
+    parameters:
+      sample: docker-linux
+      image: community-ubuntu-server-arm64
+      provider: vmware
+      hostArchitecture: ARM64

--- a/.azure-pipelines/jobs.yml
+++ b/.azure-pipelines/jobs.yml
@@ -48,7 +48,7 @@ jobs:
         displayName: Initialize Vagrant
 
       - script: |
-          dotnet cake --configuration ${{ parameters.sample }}/${{ parameters.image }}/${{ parameters.provider }}/${{ parameters.build }} --target init --reportHostAndProvider ${{ and(eq(parameters.hostArchitecture, 'ARM64'), eq(parameters.provider, 'vmware')) }}
+          dotnet cake --configuration ${{ parameters.sample }}/${{ parameters.image }}/${{ parameters.provider }}/${{ parameters.build }} --target init --reportHostAndProvider ${{ eq(parameters.hostArchitecture, 'ARM64') }}
         displayName: Init
 
       - script: |
@@ -188,7 +188,7 @@ jobs:
           displayName: Initialize Vagrant
 
         - script: |
-            dotnet cake --configuration ${{ parameters.sample }}/${{ parameters.image }}/${{ parameters.provider }}/${{ parameters.build }} --target init --reportHostAndProvider ${{ and(eq(parameters.hostArchitecture, 'ARM64'), eq(parameters.provider, 'vmware')) }}
+            dotnet cake --configuration ${{ parameters.sample }}/${{ parameters.image }}/${{ parameters.provider }}/${{ parameters.build }} --target init --reportHostAndProvider ${{ eq(parameters.hostArchitecture, 'ARM64') }}
           displayName: Init
 
         - script: |

--- a/.azure-pipelines/jobs.yml
+++ b/.azure-pipelines/jobs.yml
@@ -2,6 +2,7 @@ parameters:
   sample: ''
   image: ''
   provider: ''
+  hostArchitecture: ''
   build: ''
 
 jobs:
@@ -12,6 +13,9 @@ jobs:
       name: default
       demands:
         - VSTS_AGENT_CAP_VIRTUALIZATION_PROVIDER -equals ${{ parameters.provider }}
+        - ${{ if ne(parameters.hostArchitecture, '') }}:
+          - Agent.OS -equals Darwin
+          - Agent.OSArchitecture -equals ${{ parameters.hostArchitecture }}
 
     workspace:
       clean: all
@@ -35,6 +39,14 @@ jobs:
           packer --version
         displayName: Initialize Packer
 
+      - ${{ if and(eq(parameters.hostArchitecture, 'ARM64'), eq(parameters.provider, 'vmware')) }}:
+        - script: |
+            sw_vers
+            uname -m
+            "/Applications/VMware Fusion.app/Contents/Library/vmware-vmx" -v
+            "/opt/vagrant-vmware-desktop/bin/vagrant-vmware-utility" -version
+          displayName: Initialize host and provider
+
       - script: |
           vagrant --version
           vagrant plugin list
@@ -45,6 +57,8 @@ jobs:
 
       - script: |
           dotnet cake --configuration ${{ parameters.sample }}/${{ parameters.image }}/${{ parameters.provider }}/${{ parameters.build }} --target init
+
+          packer plugins installed
         displayName: Init
 
       - script: |
@@ -154,6 +168,9 @@ jobs:
         name: default
         demands:
           - VSTS_AGENT_CAP_VIRTUALIZATION_PROVIDER -equals ${{ parameters.provider }}
+          - ${{ if ne(parameters.hostArchitecture, '') }}:
+            - Agent.OS -equals Darwin
+            - Agent.OSArchitecture -equals ${{ parameters.hostArchitecture }}
 
       workspace:
         clean: all
@@ -172,6 +189,14 @@ jobs:
             packer --version
           displayName: Initialize Packer
 
+        - ${{ if and(eq(parameters.hostArchitecture, 'ARM64'), eq(parameters.provider, 'vmware')) }}:
+          - script: |
+              sw_vers
+              uname -m
+              "/Applications/VMware Fusion.app/Contents/Library/vmware-vmx" -v
+              "/opt/vagrant-vmware-desktop/bin/vagrant-vmware-utility" -version
+            displayName: Initialize host and provider
+
         - script: |
             vagrant --version
             vagrant plugin list
@@ -182,6 +207,8 @@ jobs:
 
         - script: |
             dotnet cake --configuration ${{ parameters.sample }}/${{ parameters.image }}/${{ parameters.provider }}/${{ parameters.build }} --target init
+
+            packer plugins installed
           displayName: Init
 
         - script: |

--- a/.azure-pipelines/jobs.yml
+++ b/.azure-pipelines/jobs.yml
@@ -39,14 +39,6 @@ jobs:
           packer --version
         displayName: Initialize Packer
 
-      - ${{ if and(eq(parameters.hostArchitecture, 'ARM64'), eq(parameters.provider, 'vmware')) }}:
-        - script: |
-            sw_vers
-            uname -m
-            "/Applications/VMware Fusion.app/Contents/Library/vmware-vmx" -v
-            "/opt/vagrant-vmware-desktop/bin/vagrant-vmware-utility" -version
-          displayName: Initialize host and provider
-
       - script: |
           vagrant --version
           vagrant plugin list
@@ -56,9 +48,7 @@ jobs:
         displayName: Initialize Vagrant
 
       - script: |
-          dotnet cake --configuration ${{ parameters.sample }}/${{ parameters.image }}/${{ parameters.provider }}/${{ parameters.build }} --target init
-
-          packer plugins installed
+          dotnet cake --configuration ${{ parameters.sample }}/${{ parameters.image }}/${{ parameters.provider }}/${{ parameters.build }} --target init --reportHostAndProvider ${{ and(eq(parameters.hostArchitecture, 'ARM64'), eq(parameters.provider, 'vmware')) }}
         displayName: Init
 
       - script: |
@@ -189,14 +179,6 @@ jobs:
             packer --version
           displayName: Initialize Packer
 
-        - ${{ if and(eq(parameters.hostArchitecture, 'ARM64'), eq(parameters.provider, 'vmware')) }}:
-          - script: |
-              sw_vers
-              uname -m
-              "/Applications/VMware Fusion.app/Contents/Library/vmware-vmx" -v
-              "/opt/vagrant-vmware-desktop/bin/vagrant-vmware-utility" -version
-            displayName: Initialize host and provider
-
         - script: |
             vagrant --version
             vagrant plugin list
@@ -206,9 +188,7 @@ jobs:
           displayName: Initialize Vagrant
 
         - script: |
-            dotnet cake --configuration ${{ parameters.sample }}/${{ parameters.image }}/${{ parameters.provider }}/${{ parameters.build }} --target init
-
-            packer plugins installed
+            dotnet cake --configuration ${{ parameters.sample }}/${{ parameters.image }}/${{ parameters.provider }}/${{ parameters.build }} --target init --reportHostAndProvider ${{ and(eq(parameters.hostArchitecture, 'ARM64'), eq(parameters.provider, 'vmware')) }}
           displayName: Init
 
         - script: |

--- a/.azure-pipelines/jobs.yml
+++ b/.azure-pipelines/jobs.yml
@@ -12,6 +12,7 @@ jobs:
     pool:
       name: default
       demands:
+        - VSTS_AGENT_CAP_PACKER -equals build
         - VSTS_AGENT_CAP_VIRTUALIZATION_PROVIDER -equals ${{ parameters.provider }}
         - ${{ if ne(parameters.hostArchitecture, '') }}:
           - Agent.OS -equals Darwin
@@ -102,7 +103,7 @@ jobs:
       pool:
         name: default
         demands:
-          - VSTS_AGENT_CAP_VIRTUALIZATION_PROVIDER -equals none
+          - VSTS_AGENT_CAP_PACKER -equals publish
 
       workspace:
         clean: all
@@ -157,6 +158,7 @@ jobs:
       pool:
         name: default
         demands:
+          - VSTS_AGENT_CAP_PACKER -equals build
           - VSTS_AGENT_CAP_VIRTUALIZATION_PROVIDER -equals ${{ parameters.provider }}
           - ${{ if ne(parameters.hostArchitecture, '') }}:
             - Agent.OS -equals Darwin

--- a/.azure-pipelines/kitchen-ubuntu/2204-arm64/virtualbox.yml
+++ b/.azure-pipelines/kitchen-ubuntu/2204-arm64/virtualbox.yml
@@ -1,0 +1,15 @@
+trigger: none
+pr: none
+
+resources:
+  pipelines:
+    - pipeline: source
+      source: ubuntu-server.2204-lts-arm64.virtualbox
+
+stages:
+  - template: ../../stages.yml
+    parameters:
+      sample: kitchen-ubuntu
+      image: 2204-arm64
+      provider: virtualbox
+      hostArchitecture: ARM64

--- a/.azure-pipelines/kitchen-ubuntu/2204-arm64/vmware.yml
+++ b/.azure-pipelines/kitchen-ubuntu/2204-arm64/vmware.yml
@@ -1,0 +1,15 @@
+trigger: none
+pr: none
+
+resources:
+  pipelines:
+    - pipeline: source
+      source: ubuntu-server.2204-lts-arm64.vmware
+
+stages:
+  - template: ../../stages.yml
+    parameters:
+      sample: kitchen-ubuntu
+      image: 2204-arm64
+      provider: vmware
+      hostArchitecture: ARM64

--- a/.azure-pipelines/kitchen-ubuntu/2404-arm64/virtualbox.yml
+++ b/.azure-pipelines/kitchen-ubuntu/2404-arm64/virtualbox.yml
@@ -1,0 +1,15 @@
+trigger: none
+pr: none
+
+resources:
+  pipelines:
+    - pipeline: source
+      source: ubuntu-server.2404-lts-arm64.virtualbox
+
+stages:
+  - template: ../../stages.yml
+    parameters:
+      sample: kitchen-ubuntu
+      image: 2404-arm64
+      provider: virtualbox
+      hostArchitecture: ARM64

--- a/.azure-pipelines/kitchen-ubuntu/2404-arm64/vmware.yml
+++ b/.azure-pipelines/kitchen-ubuntu/2404-arm64/vmware.yml
@@ -1,0 +1,15 @@
+trigger: none
+pr: none
+
+resources:
+  pipelines:
+    - pipeline: source
+      source: ubuntu-server.2404-lts-arm64.vmware
+
+stages:
+  - template: ../../stages.yml
+    parameters:
+      sample: kitchen-ubuntu
+      image: 2404-arm64
+      provider: vmware
+      hostArchitecture: ARM64

--- a/.azure-pipelines/stages.yml
+++ b/.azure-pipelines/stages.yml
@@ -2,6 +2,7 @@ parameters:
   sample: ''
   image: ''
   provider: ''
+  hostArchitecture: ''
 
 stages:
   - stage: native
@@ -13,6 +14,7 @@ stages:
           sample: ${{ parameters.sample }}
           image: ${{ parameters.image }}
           provider: ${{ parameters.provider }}
+          hostArchitecture: ${{ parameters.hostArchitecture }}
           build: native
 
   - stage: vagrant
@@ -24,4 +26,5 @@ stages:
           sample: ${{ parameters.sample }}
           image: ${{ parameters.image }}
           provider: ${{ parameters.provider }}
+          hostArchitecture: ${{ parameters.hostArchitecture }}
           build: vagrant

--- a/.azure-pipelines/ubuntu-desktop/2204-lts-ubuntu-arm64/virtualbox.yml
+++ b/.azure-pipelines/ubuntu-desktop/2204-lts-ubuntu-arm64/virtualbox.yml
@@ -1,0 +1,15 @@
+trigger: none
+pr: none
+
+resources:
+  pipelines:
+    - pipeline: source
+      source: ubuntu-server.2204-lts-arm64.virtualbox
+
+stages:
+  - template: ../../stages.yml
+    parameters:
+      sample: ubuntu-desktop
+      image: 2204-lts-ubuntu-arm64
+      provider: virtualbox
+      hostArchitecture: ARM64

--- a/.azure-pipelines/ubuntu-desktop/2204-lts-ubuntu-arm64/vmware.yml
+++ b/.azure-pipelines/ubuntu-desktop/2204-lts-ubuntu-arm64/vmware.yml
@@ -1,0 +1,15 @@
+trigger: none
+pr: none
+
+resources:
+  pipelines:
+    - pipeline: source
+      source: ubuntu-server.2204-lts-arm64.vmware
+
+stages:
+  - template: ../../stages.yml
+    parameters:
+      sample: ubuntu-desktop
+      image: 2204-lts-ubuntu-arm64
+      provider: vmware
+      hostArchitecture: ARM64

--- a/.azure-pipelines/ubuntu-desktop/2204-lts-xubuntu-arm64/virtualbox.yml
+++ b/.azure-pipelines/ubuntu-desktop/2204-lts-xubuntu-arm64/virtualbox.yml
@@ -1,0 +1,15 @@
+trigger: none
+pr: none
+
+resources:
+  pipelines:
+    - pipeline: source
+      source: ubuntu-server.2204-lts-arm64.virtualbox
+
+stages:
+  - template: ../../stages.yml
+    parameters:
+      sample: ubuntu-desktop
+      image: 2204-lts-xubuntu-arm64
+      provider: virtualbox
+      hostArchitecture: ARM64

--- a/.azure-pipelines/ubuntu-desktop/2204-lts-xubuntu-arm64/vmware.yml
+++ b/.azure-pipelines/ubuntu-desktop/2204-lts-xubuntu-arm64/vmware.yml
@@ -1,0 +1,15 @@
+trigger: none
+pr: none
+
+resources:
+  pipelines:
+    - pipeline: source
+      source: ubuntu-server.2204-lts-arm64.vmware
+
+stages:
+  - template: ../../stages.yml
+    parameters:
+      sample: ubuntu-desktop
+      image: 2204-lts-xubuntu-arm64
+      provider: vmware
+      hostArchitecture: ARM64

--- a/.azure-pipelines/ubuntu-desktop/2404-lts-ubuntu-arm64/virtualbox.yml
+++ b/.azure-pipelines/ubuntu-desktop/2404-lts-ubuntu-arm64/virtualbox.yml
@@ -1,0 +1,10 @@
+trigger: none
+pr: none
+
+stages:
+  - template: ../../stages.yml
+    parameters:
+      sample: ubuntu-desktop
+      image: 2404-lts-ubuntu-arm64
+      provider: virtualbox
+      hostArchitecture: ARM64

--- a/.azure-pipelines/ubuntu-desktop/2404-lts-ubuntu-arm64/vmware.yml
+++ b/.azure-pipelines/ubuntu-desktop/2404-lts-ubuntu-arm64/vmware.yml
@@ -1,0 +1,10 @@
+trigger: none
+pr: none
+
+stages:
+  - template: ../../stages.yml
+    parameters:
+      sample: ubuntu-desktop
+      image: 2404-lts-ubuntu-arm64
+      provider: vmware
+      hostArchitecture: ARM64

--- a/.azure-pipelines/ubuntu-desktop/2404-lts-xubuntu-arm64/virtualbox.yml
+++ b/.azure-pipelines/ubuntu-desktop/2404-lts-xubuntu-arm64/virtualbox.yml
@@ -1,0 +1,15 @@
+trigger: none
+pr: none
+
+resources:
+  pipelines:
+    - pipeline: source
+      source: ubuntu-server.2404-lts-arm64.virtualbox
+
+stages:
+  - template: ../../stages.yml
+    parameters:
+      sample: ubuntu-desktop
+      image: 2404-lts-xubuntu-arm64
+      provider: virtualbox
+      hostArchitecture: ARM64

--- a/.azure-pipelines/ubuntu-desktop/2404-lts-xubuntu-arm64/vmware.yml
+++ b/.azure-pipelines/ubuntu-desktop/2404-lts-xubuntu-arm64/vmware.yml
@@ -1,0 +1,15 @@
+trigger: none
+pr: none
+
+resources:
+  pipelines:
+    - pipeline: source
+      source: ubuntu-server.2404-lts-arm64.vmware
+
+stages:
+  - template: ../../stages.yml
+    parameters:
+      sample: ubuntu-desktop
+      image: 2404-lts-xubuntu-arm64
+      provider: vmware
+      hostArchitecture: ARM64

--- a/.azure-pipelines/ubuntu-server/2204-lts-arm64/virtualbox.yml
+++ b/.azure-pipelines/ubuntu-server/2204-lts-arm64/virtualbox.yml
@@ -1,0 +1,10 @@
+trigger: none
+pr: none
+
+stages:
+  - template: ../../stages.yml
+    parameters:
+      sample: ubuntu-server
+      image: 2204-lts-arm64
+      provider: virtualbox
+      hostArchitecture: ARM64

--- a/.azure-pipelines/ubuntu-server/2204-lts-arm64/vmware.yml
+++ b/.azure-pipelines/ubuntu-server/2204-lts-arm64/vmware.yml
@@ -1,0 +1,10 @@
+trigger: none
+pr: none
+
+stages:
+  - template: ../../stages.yml
+    parameters:
+      sample: ubuntu-server
+      image: 2204-lts-arm64
+      provider: vmware
+      hostArchitecture: ARM64

--- a/.azure-pipelines/ubuntu-server/2404-lts-arm64/virtualbox.yml
+++ b/.azure-pipelines/ubuntu-server/2404-lts-arm64/virtualbox.yml
@@ -1,0 +1,10 @@
+trigger: none
+pr: none
+
+stages:
+  - template: ../../stages.yml
+    parameters:
+      sample: ubuntu-server
+      image: 2404-lts-arm64
+      provider: virtualbox
+      hostArchitecture: ARM64

--- a/.azure-pipelines/ubuntu-server/2404-lts-arm64/vmware.yml
+++ b/.azure-pipelines/ubuntu-server/2404-lts-arm64/vmware.yml
@@ -1,0 +1,10 @@
+trigger: none
+pr: none
+
+stages:
+  - template: ../../stages.yml
+    parameters:
+      sample: ubuntu-server
+      image: 2404-lts-arm64
+      provider: vmware
+      hostArchitecture: ARM64

--- a/.azure-pipelines/windows-11/25h2-professional-arm64/virtualbox.yml
+++ b/.azure-pipelines/windows-11/25h2-professional-arm64/virtualbox.yml
@@ -1,0 +1,10 @@
+trigger: none
+pr: none
+
+stages:
+  - template: ../../stages.yml
+    parameters:
+      sample: windows-11
+      image: 25h2-professional-arm64
+      provider: virtualbox
+      hostArchitecture: ARM64

--- a/.azure-pipelines/windows-11/25h2-professional-arm64/vmware.yml
+++ b/.azure-pipelines/windows-11/25h2-professional-arm64/vmware.yml
@@ -1,0 +1,10 @@
+trigger: none
+pr: none
+
+stages:
+  - template: ../../stages.yml
+    parameters:
+      sample: windows-11
+      image: 25h2-professional-arm64
+      provider: vmware
+      hostArchitecture: ARM64

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ When a container command cannot reach the local Docker daemon from the sandbox, 
 
 ## Coding Style & Naming Conventions
 
-Run `packer fmt` for HCL. Use two-space indentation in Ruby, YAML, and Cake files, and follow existing PowerShell and shell conventions. Ruby style is governed by `.rubocop.yml`; generated and vendored `lib/` content is excluded. Do not hard-wrap prose in Markdown files or GitHub issue and pull request content; keep each paragraph or list item on one source line and let the renderer wrap it. Preserve repository line endings: LF for shell scripts and CRLF for PowerShell. Use lowercase, hyphenated sample and image-variant directories (for example, `ubuntu-server` and `25h2-enterprise`), and keep provider-specific files named consistently, such as `source.virtualbox.pkr.hcl`.
+Run `packer fmt` for HCL. Use Packer input variables only to capture external input; assign them to descriptively named locals and use locals everywhere else, including for all derived values. Use two-space indentation in Ruby, YAML, and Cake files, and follow existing PowerShell and shell conventions. Ruby style is governed by `.rubocop.yml`; generated and vendored `lib/` content is excluded. Do not hard-wrap prose in Markdown files or GitHub issue and pull request content; keep each paragraph or list item on one source line and let the renderer wrap it. Preserve repository line endings: LF for shell scripts and CRLF for PowerShell. Use lowercase, hyphenated sample and image-variant directories (for example, `ubuntu-server` and `25h2-enterprise`), and keep provider-specific files named consistently, such as `source.virtualbox.pkr.hcl`.
 
 ## Testing Guidelines
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@
 - `dotnet cake --configuration <sample>/<image>/<provider>/<build>` runs the default `init`, `restore`, `build`, and `test` pipeline.
 - `dotnet cake --configuration <...> --target clean` removes generated artifacts.
 
-Valid providers include `virtualbox`, `vmware`, `hyperv`, and `qemu`; builds require the matching local virtualization stack and can take over two hours.
+Valid providers include `virtualbox`, `vmware`, `hyperv`, and `qemu`; builds require the matching local virtualization stack. Ubuntu native builds typically take about 10 minutes from an ISO and less when derived, while Ubuntu Vagrant builds usually take under 5 minutes. Windows native ISO builds usually take about an hour and can be faster when derived; Windows Vagrant builds usually take 5–10 minutes.
 
 When a container command cannot reach the local Docker daemon from the sandbox, retry that same command outside the sandbox before installing or compiling alternative tooling.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@
 
 - `dotnet tool restore` installs the repository-pinned Cake 4.0 tool.
 - `packer fmt -check src` checks HCL formatting before review; use `packer fmt src` to apply it.
+- `docker compose --file docs/site/compose.yml up --build` builds and serves the public Jekyll site at `http://localhost:4000` for documentation verification.
 - `dotnet cake --configuration windows-11/25h2-enterprise/virtualbox/native --target init` initializes required Packer plugins.
 - `dotnet cake --configuration <sample>/<image>/<provider>/<build>` runs the default `init`, `restore`, `build`, and `test` pipeline.
 - `dotnet cake --configuration <...> --target clean` removes generated artifacts.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -14,9 +14,11 @@ target different guest operating systems.
 _Avoid_: scenario
 
 **Image variant**:
-A catalog choice within an image family that fulfills the family's intent for one
-guest operating system and a particular operating-system release, edition,
-desktop, or workload combination.
+A catalog choice within an image family that fulfills the family's intent for one guest operating system, guest architecture, and a particular operating-system release, edition, desktop, or workload combination.
+
+**Guest architecture**:
+The processor architecture targeted by an image variant, such as AMD64 or ARM64.
+_Avoid_: host architecture, platform
 
 **Guest operating system**:
 The operating system targeted by an image variant, such as Windows or Ubuntu.

--- a/build.cake
+++ b/build.cake
@@ -1,5 +1,6 @@
 var configuration = Argument("configuration", string.Empty);
 var target = Argument("target", "default");
+var reportHostAndProvider = Argument("reportHostAndProvider", false);
 
 var author = Argument("author", "gusztavvargadr");
 var version = Argument("version", "2607.1.0");
@@ -60,10 +61,41 @@ Task("default")
 RunTarget(target);
 
 void PackerInit() {
+  ReportHostAndProvider();
+
   var arguments = new ProcessArgumentBuilder();
 
   arguments.Append("init");
   arguments.Append(platformDirectory);
+
+  Packer(arguments);
+
+  PackerPluginList();
+}
+
+void ReportHostAndProvider() {
+  if (!reportHostAndProvider) {
+    return;
+  }
+
+  if (!IsRunningOnMacOs() || provider != "vmware") {
+    throw new Exception("Host and provider reporting requires VMware on macOS.");
+  }
+
+  RunVersionCommand("sw_vers");
+  RunVersionCommand("uname", "-m");
+
+  var vmwareVmx = "/Applications/VMware Fusion.app/Contents/Library/vmware-vmx";
+  RunVersionCommand(vmwareVmx, "-v");
+
+  var vagrantVmwareUtility = "/opt/vagrant-vmware-desktop/bin/vagrant-vmware-utility";
+  RunVersionCommand(vagrantVmwareUtility, "-version");
+}
+
+void PackerPluginList() {
+  var arguments = new ProcessArgumentBuilder();
+
+  arguments.Append("plugins installed");
 
   Packer(arguments);
 }
@@ -94,5 +126,20 @@ void Packer(ProcessArgumentBuilder arguments) {
   
   if (result != 0) {
     throw new Exception($"Packer failed with code {result} .");
+  }
+}
+
+void RunVersionCommand(string executable, string argument = "") {
+  var arguments = new ProcessArgumentBuilder();
+  if (!string.IsNullOrEmpty(argument)) {
+    arguments.Append(argument);
+  }
+
+  var result = StartProcess(executable, new ProcessSettings {
+    Arguments = arguments
+  });
+
+  if (result != 0) {
+    throw new Exception($"{executable} failed with code {result} .");
   }
 }

--- a/build.cake
+++ b/build.cake
@@ -78,18 +78,28 @@ void ReportHostAndProvider() {
     return;
   }
 
-  if (!IsRunningOnMacOs() || provider != "vmware") {
-    throw new Exception("Host and provider reporting requires VMware on macOS.");
+  if (!IsRunningOnMacOs()) {
+    throw new Exception("Host and provider reporting requires macOS.");
   }
 
   RunVersionCommand("sw_vers");
   RunVersionCommand("uname", "-m");
 
-  var vmwareVmx = "/Applications/VMware Fusion.app/Contents/Library/vmware-vmx";
-  RunVersionCommand(vmwareVmx, "-v");
+  if (provider == "vmware") {
+    var vmwareVmx = "/Applications/VMware Fusion.app/Contents/Library/vmware-vmx";
+    RunVersionCommand(vmwareVmx, "-v");
 
-  var vagrantVmwareUtility = "/opt/vagrant-vmware-desktop/bin/vagrant-vmware-utility";
-  RunVersionCommand(vagrantVmwareUtility, "-version");
+    var vagrantVmwareUtility = "/opt/vagrant-vmware-desktop/bin/vagrant-vmware-utility";
+    RunVersionCommand(vagrantVmwareUtility, "-version");
+    return;
+  }
+
+  if (provider == "virtualbox") {
+    RunVersionCommand("VBoxManage", "--version");
+    return;
+  }
+
+  throw new Exception($"Host and provider reporting does not support {provider}.");
 }
 
 void PackerPluginList() {

--- a/build.cake
+++ b/build.cake
@@ -2,7 +2,7 @@ var configuration = Argument("configuration", string.Empty);
 var target = Argument("target", "default");
 
 var author = Argument("author", "gusztavvargadr");
-var version = Argument("version", "2607");
+var version = Argument("version", "2607.1.0");
 
 var configurationParts = configuration.Split('/', StringSplitOptions.RemoveEmptyEntries);
 var sample = configurationParts.ElementAtOrDefault(0) ?? Argument<string>("sample");

--- a/docs/adr/0003-let-windows-11-alias-span-editions-by-architecture.md
+++ b/docs/adr/0003-let-windows-11-alias-span-editions-by-architecture.md
@@ -1,0 +1,9 @@
+---
+status: accepted
+---
+
+# Let the Windows 11 alias span editions by guest architecture
+
+Microsoft does not publish a suitable Windows 11 25H2 Enterprise ARM64 evaluation image, while a Professional ARM64 image is available. Publish the ARM64 variant canonically as `windows-11-25h2-professional` and keep the AMD64 Enterprise variant under its existing canonical name; the generic `windows-11` alias may reference Enterprise on AMD64 and Professional on ARM64. The alias denotes the latest supported Windows 11 variant for each guest architecture rather than a common edition across architectures. This preserves a stable multi-architecture alias without misrepresenting the edition of either canonical box, and the architecture-dependent edition difference must be documented for consumers.
+
+This decision was made while defining ARM64 support in [#533](https://github.com/gusztavvargadr/packer/issues/533).

--- a/docs/site/arm64.md
+++ b/docs/site/arm64.md
@@ -21,27 +21,16 @@ ARM64 images are native Apple-silicon guest images. They use the same canonical 
 | [Kitchen on Ubuntu 22.04]({{ site.baseurl }}{% link images/kitchen/ubuntu-2204/index.md %}) | ARM64 | VirtualBox, VMware |
 | [Development on Ubuntu 24.04]({{ site.baseurl }}{% link images/development/ubuntu-2404/index.md %}) | ARM64 | VirtualBox, VMware |
 | [Development on Ubuntu 22.04]({{ site.baseurl }}{% link images/development/ubuntu-2204/index.md %}) | ARM64 | VirtualBox, VMware |
-| Windows 11 Version 25H2 Professional | ARM64 | VirtualBox, VMware |
+| [Windows 11 Version 25H2 Professional]({{ site.baseurl }}{% link images/windows-11/25h2-professional/index.md %}) | ARM64 | VirtualBox, VMware |
 
-### Ubuntu Desktop release components
-
-| Image | Native source |
-| --- | --- |
-| Ubuntu Desktop 24.04 LTS | `ubuntu-24.04.4-desktop-arm64.iso` (`sha256:c2610520bf582976839a1724c669e1cfed0547427be5a0ad12d457b92b46ffbe`) |
-| Ubuntu Desktop 22.04 LTS | Matching-provider `ubuntu-server/2204-lts-arm64` native image, built from `ubuntu-22.04.5-live-server-arm64.iso` (`sha256:eafec62cfe760c30cac43f446463e628fada468c2de2f14e0e2bc27295187505`) |
-
-VirtualBox Guest Additions are not installed on Ubuntu ARM64 images because [VirtualBox does not list Ubuntu among the supported ARM64 Guest Additions platforms](https://www.virtualbox.org/manual/topics/guestadditions.html). VMware uses Ubuntu's `open-vm-tools` and `open-vm-tools-desktop` packages. Each authoritative pipeline run records the exact host, provider, Packer, plugin, Vagrant, and guest-tool versions used for validation.
-
-### Prerequisites
+### Requirements and limitations
 
 - An Apple-silicon Mac running the latest stable macOS release
-- The latest stable VirtualBox release, or the latest stable VMware Fusion release and VMware Utility
-- The latest stable Packer and Vagrant releases, including the provider's Packer and Vagrant plugins
-- Sufficient free disk space for the installation ISO, native image, and Vagrant box
+- The latest stable VirtualBox release, or the latest stable VMware Fusion release
+- The latest stable Vagrant release; VMware also requires the Vagrant VMware Utility and provider plugin
+- Sufficient free disk space for the Vagrant box and virtual machine
 
-Windows builds require the manually downloaded Windows 11 25H2 ARM64 installation ISO. VirtualBox builds download and install Guest Additions for the exact host VirtualBox version using the existing version-derived download URL shared across Windows guest architectures. VMware builds obtain the required ARM64 `vmxnet3` boot driver from `drivers-arm64.zip` in the configured VMware Fusion application and download VMware Tools inside the guest from the architecture-specific URL validated for the release. The Fusion application defaults to `/Applications/VMware Fusion.app`; set `PKR_VAR_vmware_fusion_application_path` to use a different location.
-
-The manually queued ARM64 pipelines are the authoritative end-to-end validation. They require Azure agents advertising `Agent.OS=Darwin`, `Agent.OSArchitecture=ARM64`, and the selected `virtualbox` or `vmware` provider capability, and report the exact macOS, provider, Packer, Packer plugin, Vagrant, Vagrant plugin, and guest-tool versions used by each run.
+VirtualBox Guest Additions are not installed on Ubuntu ARM64 images because [VirtualBox does not list Ubuntu among the supported ARM64 Guest Additions platforms](https://www.virtualbox.org/manual/topics/guestadditions.html). VMware images use the supported guest tools for their operating system.
 
 ### Using the ARM64 box
 
@@ -54,7 +43,7 @@ config.vm.box_architecture = "arm64"
 
 Start the machine with an existing provider identity, for example `vagrant up --provider virtualbox` or `vagrant up --provider vmware_desktop`.
 
-The canonical `ubuntu-server-2404-lts` box and the `ubuntu-server` alias remain AMD64 by default for compatibility. ARM64 publication adds an architecture-specific artifact under the normal catalog release version.
+The canonical `ubuntu-server-2404-lts` box and the `ubuntu-server` alias remain AMD64 by default for compatibility. ARM64 releases add architecture-specific artifacts under the normal catalog versions.
 
 Windows 11 uses architecture-dependent editions. The generic `windows-11` alias continues to target Windows 11 25H2 Enterprise on AMD64 and targets Windows 11 25H2 Professional on ARM64. The Professional ARM64 artifact is published truthfully as `windows-11-25h2-professional` and defaults to ARM64 because that canonical box is ARM64-only; the multi-architecture alias remains AMD64 by default.
 

--- a/docs/site/arm64.md
+++ b/docs/site/arm64.md
@@ -12,6 +12,8 @@ ARM64 images are native Apple-silicon guest images. They use the same canonical 
 | --- | --- | --- |
 | [Ubuntu Server 24.04 LTS]({{ site.baseurl }}{% link images/ubuntu-server/2404-lts/index.md %}) | ARM64 | VirtualBox, VMware |
 | [Ubuntu Server 22.04 LTS]({{ site.baseurl }}{% link images/ubuntu-server/2204-lts/index.md %}) | ARM64 | VirtualBox, VMware |
+| [Xubuntu Desktop 24.04 LTS]({{ site.baseurl }}{% link images/xubuntu-desktop/2404-lts/index.md %}) | ARM64 | VirtualBox, VMware |
+| [Xubuntu Desktop 22.04 LTS]({{ site.baseurl }}{% link images/xubuntu-desktop/2204-lts/index.md %}) | ARM64 | VirtualBox, VMware |
 | Windows 11 Version 25H2 Professional | ARM64 | VMware |
 
 ### Prerequisites

--- a/docs/site/arm64.md
+++ b/docs/site/arm64.md
@@ -14,6 +14,9 @@ ARM64 images are native Apple-silicon guest images. They use the same canonical 
 | [Ubuntu Server 22.04 LTS]({{ site.baseurl }}{% link images/ubuntu-server/2204-lts/index.md %}) | ARM64 | VirtualBox, VMware |
 | [Xubuntu Desktop 24.04 LTS]({{ site.baseurl }}{% link images/xubuntu-desktop/2404-lts/index.md %}) | ARM64 | VirtualBox, VMware |
 | [Xubuntu Desktop 22.04 LTS]({{ site.baseurl }}{% link images/xubuntu-desktop/2204-lts/index.md %}) | ARM64 | VirtualBox, VMware |
+| [Docker on Ubuntu 24.04]({{ site.baseurl }}{% link images/docker/ubuntu-2404/index.md %}) | ARM64 | VirtualBox, VMware |
+| [Kitchen on Ubuntu 24.04]({{ site.baseurl }}{% link images/kitchen/ubuntu-2404/index.md %}) | ARM64 | VirtualBox, VMware |
+| [Kitchen on Ubuntu 22.04]({{ site.baseurl }}{% link images/kitchen/ubuntu-2204/index.md %}) | ARM64 | VirtualBox, VMware |
 | Windows 11 Version 25H2 Professional | ARM64 | VMware |
 
 ### Prerequisites

--- a/docs/site/arm64.md
+++ b/docs/site/arm64.md
@@ -1,0 +1,37 @@
+---
+layout: page
+title: ARM64 Support
+navbar_include: true
+---
+
+ARM64 images are native Apple-silicon guest images. They use the same canonical Vagrant box names, release versions, and provider identities as their AMD64 counterparts; Vagrant selects the matching artifact by architecture.
+
+### Supported images
+
+| Image | Architecture | Providers |
+| --- | --- | --- |
+| [Ubuntu Server 24.04 LTS]({{ site.baseurl }}{% link images/ubuntu-server/2404-lts/index.md %}) | ARM64 | VMware |
+
+### Prerequisites
+
+- An Apple-silicon Mac running the latest stable macOS release
+- The latest stable VMware Fusion release and VMware Utility
+- The latest stable Packer and Vagrant releases, including the Packer VMware plugin and Vagrant VMware Desktop provider plugin
+- Sufficient free disk space for the Ubuntu installation ISO, native image, and Vagrant box
+
+The manually queued ARM64 pipeline is the authoritative end-to-end validation. It requires Azure agents advertising `Agent.OS=Darwin`, `Agent.OSArchitecture=ARM64`, and the existing `vmware` provider capability, and reports the exact macOS, VMware Fusion, Packer, Packer plugin, Vagrant, and Vagrant plugin versions used by each run.
+
+### Using the ARM64 box
+
+Select the ARM64 artifact explicitly when defining a machine:
+
+```ruby
+config.vm.box = "gusztavvargadr/ubuntu-server-2404-lts"
+config.vm.box_architecture = "arm64"
+```
+
+Start the machine with the existing VMware provider identity, for example `vagrant up --provider vmware_desktop`.
+
+The canonical `ubuntu-server-2404-lts` box and the `ubuntu-server` alias remain AMD64 by default for compatibility. ARM64 publication adds an architecture-specific artifact under the normal catalog release version.
+
+ARM64 support currently excludes VirtualBox, Hyper-V, QEMU/libvirt, Windows guests, and Intel Macs. Additional image and provider combinations will be listed here after their native build, Vagrant packaging, publication, and downloaded-box boot gates pass.

--- a/docs/site/arm64.md
+++ b/docs/site/arm64.md
@@ -12,6 +12,8 @@ ARM64 images are native Apple-silicon guest images. They use the same canonical 
 | --- | --- | --- |
 | [Ubuntu Server 24.04 LTS]({{ site.baseurl }}{% link images/ubuntu-server/2404-lts/index.md %}) | ARM64 | VirtualBox, VMware |
 | [Ubuntu Server 22.04 LTS]({{ site.baseurl }}{% link images/ubuntu-server/2204-lts/index.md %}) | ARM64 | VirtualBox, VMware |
+| [Ubuntu Desktop 24.04 LTS]({{ site.baseurl }}{% link images/ubuntu-desktop/2404-lts/index.md %}) | ARM64 | VirtualBox, VMware |
+| [Ubuntu Desktop 22.04 LTS]({{ site.baseurl }}{% link images/ubuntu-desktop/2204-lts/index.md %}) | ARM64 | VirtualBox, VMware |
 | [Xubuntu Desktop 24.04 LTS]({{ site.baseurl }}{% link images/xubuntu-desktop/2404-lts/index.md %}) | ARM64 | VirtualBox, VMware |
 | [Xubuntu Desktop 22.04 LTS]({{ site.baseurl }}{% link images/xubuntu-desktop/2204-lts/index.md %}) | ARM64 | VirtualBox, VMware |
 | [Docker on Ubuntu 24.04]({{ site.baseurl }}{% link images/docker/ubuntu-2404/index.md %}) | ARM64 | VirtualBox, VMware |

--- a/docs/site/arm64.md
+++ b/docs/site/arm64.md
@@ -10,16 +10,17 @@ ARM64 images are native Apple-silicon guest images. They use the same canonical 
 
 | Image | Architecture | Providers |
 | --- | --- | --- |
-| [Ubuntu Server 24.04 LTS]({{ site.baseurl }}{% link images/ubuntu-server/2404-lts/index.md %}) | ARM64 | VMware |
+| [Ubuntu Server 24.04 LTS]({{ site.baseurl }}{% link images/ubuntu-server/2404-lts/index.md %}) | ARM64 | VirtualBox, VMware |
+| [Ubuntu Server 22.04 LTS]({{ site.baseurl }}{% link images/ubuntu-server/2204-lts/index.md %}) | ARM64 | VirtualBox, VMware |
 
 ### Prerequisites
 
 - An Apple-silicon Mac running the latest stable macOS release
-- The latest stable VMware Fusion release and VMware Utility
-- The latest stable Packer and Vagrant releases, including the Packer VMware plugin and Vagrant VMware Desktop provider plugin
+- The latest stable VirtualBox release, or the latest stable VMware Fusion release and VMware Utility
+- The latest stable Packer and Vagrant releases, including the provider's Packer and Vagrant plugins
 - Sufficient free disk space for the Ubuntu installation ISO, native image, and Vagrant box
 
-The manually queued ARM64 pipeline is the authoritative end-to-end validation. It requires Azure agents advertising `Agent.OS=Darwin`, `Agent.OSArchitecture=ARM64`, and the existing `vmware` provider capability, and reports the exact macOS, VMware Fusion, Packer, Packer plugin, Vagrant, and Vagrant plugin versions used by each run.
+The manually queued ARM64 pipelines are the authoritative end-to-end validation. They require Azure agents advertising `Agent.OS=Darwin`, `Agent.OSArchitecture=ARM64`, and the selected `virtualbox` or `vmware` provider capability, and report the exact macOS, provider, Packer, Packer plugin, Vagrant, Vagrant plugin, and guest-tool versions used by each run.
 
 ### Using the ARM64 box
 
@@ -30,8 +31,8 @@ config.vm.box = "gusztavvargadr/ubuntu-server-2404-lts"
 config.vm.box_architecture = "arm64"
 ```
 
-Start the machine with the existing VMware provider identity, for example `vagrant up --provider vmware_desktop`.
+Start the machine with an existing provider identity, for example `vagrant up --provider virtualbox` or `vagrant up --provider vmware_desktop`.
 
 The canonical `ubuntu-server-2404-lts` box and the `ubuntu-server` alias remain AMD64 by default for compatibility. ARM64 publication adds an architecture-specific artifact under the normal catalog release version.
 
-ARM64 support currently excludes VirtualBox, Hyper-V, QEMU/libvirt, Windows guests, and Intel Macs. Additional image and provider combinations will be listed here after their native build, Vagrant packaging, publication, and downloaded-box boot gates pass.
+ARM64 support currently excludes Hyper-V, QEMU/libvirt, Windows guests, and Intel Macs. Additional image and provider combinations will be listed here after their native build, Vagrant packaging, publication, and downloaded-box boot gates pass.

--- a/docs/site/arm64.md
+++ b/docs/site/arm64.md
@@ -21,6 +21,15 @@ ARM64 images are native Apple-silicon guest images. They use the same canonical 
 | [Kitchen on Ubuntu 22.04]({{ site.baseurl }}{% link images/kitchen/ubuntu-2204/index.md %}) | ARM64 | VirtualBox, VMware |
 | Windows 11 Version 25H2 Professional | ARM64 | VMware |
 
+### Ubuntu Desktop release components
+
+| Image | Native source |
+| --- | --- |
+| Ubuntu Desktop 24.04 LTS | `ubuntu-24.04.4-desktop-arm64.iso` (`sha256:c2610520bf582976839a1724c669e1cfed0547427be5a0ad12d457b92b46ffbe`) |
+| Ubuntu Desktop 22.04 LTS | Matching-provider `ubuntu-server/2204-lts-arm64` native image, built from `ubuntu-22.04.5-live-server-arm64.iso` (`sha256:eafec62cfe760c30cac43f446463e628fada468c2de2f14e0e2bc27295187505`) |
+
+For both variants, VirtualBox Guest Additions must match the exact host VirtualBox version, while VMware uses Ubuntu's `open-vm-tools` and `open-vm-tools-desktop` packages. Each authoritative pipeline run records the exact host, provider, Packer, plugin, Vagrant, and guest-tool versions used for validation.
+
 ### Prerequisites
 
 - An Apple-silicon Mac running the latest stable macOS release

--- a/docs/site/arm64.md
+++ b/docs/site/arm64.md
@@ -28,7 +28,7 @@ ARM64 images are native Apple-silicon guest images. They use the same canonical 
 | Ubuntu Desktop 24.04 LTS | `ubuntu-24.04.4-desktop-arm64.iso` (`sha256:c2610520bf582976839a1724c669e1cfed0547427be5a0ad12d457b92b46ffbe`) |
 | Ubuntu Desktop 22.04 LTS | Matching-provider `ubuntu-server/2204-lts-arm64` native image, built from `ubuntu-22.04.5-live-server-arm64.iso` (`sha256:eafec62cfe760c30cac43f446463e628fada468c2de2f14e0e2bc27295187505`) |
 
-For both variants, VirtualBox Guest Additions must match the exact host VirtualBox version, while VMware uses Ubuntu's `open-vm-tools` and `open-vm-tools-desktop` packages. Each authoritative pipeline run records the exact host, provider, Packer, plugin, Vagrant, and guest-tool versions used for validation.
+VirtualBox Guest Additions are not installed on Ubuntu ARM64 images because [VirtualBox does not list Ubuntu among the supported ARM64 Guest Additions platforms](https://www.virtualbox.org/manual/topics/guestadditions.html). VMware uses Ubuntu's `open-vm-tools` and `open-vm-tools-desktop` packages. Each authoritative pipeline run records the exact host, provider, Packer, plugin, Vagrant, and guest-tool versions used for validation.
 
 ### Prerequisites
 

--- a/docs/site/arm64.md
+++ b/docs/site/arm64.md
@@ -21,7 +21,7 @@ ARM64 images are native Apple-silicon guest images. They use the same canonical 
 | [Kitchen on Ubuntu 22.04]({{ site.baseurl }}{% link images/kitchen/ubuntu-2204/index.md %}) | ARM64 | VirtualBox, VMware |
 | [Development on Ubuntu 24.04]({{ site.baseurl }}{% link images/development/ubuntu-2404/index.md %}) | ARM64 | VirtualBox, VMware |
 | [Development on Ubuntu 22.04]({{ site.baseurl }}{% link images/development/ubuntu-2204/index.md %}) | ARM64 | VirtualBox, VMware |
-| Windows 11 Version 25H2 Professional | ARM64 | VMware |
+| Windows 11 Version 25H2 Professional | ARM64 | VirtualBox, VMware |
 
 ### Ubuntu Desktop release components
 
@@ -39,7 +39,7 @@ VirtualBox Guest Additions are not installed on Ubuntu ARM64 images because [Vir
 - The latest stable Packer and Vagrant releases, including the provider's Packer and Vagrant plugins
 - Sufficient free disk space for the installation ISO, native image, and Vagrant box
 
-Windows builds require the manually downloaded Windows 11 25H2 ARM64 installation ISO. VMware builds obtain the required ARM64 `vmxnet3` boot driver from `drivers-arm64.zip` in the configured VMware Fusion application and download VMware Tools inside the guest from the architecture-specific URL validated for the release. The Fusion application defaults to `/Applications/VMware Fusion.app`; set `PKR_VAR_vmware_fusion_application_path` to use a different location.
+Windows builds require the manually downloaded Windows 11 25H2 ARM64 installation ISO. VirtualBox builds download and install Guest Additions for the exact host VirtualBox version using the existing version-derived download URL shared across Windows guest architectures. VMware builds obtain the required ARM64 `vmxnet3` boot driver from `drivers-arm64.zip` in the configured VMware Fusion application and download VMware Tools inside the guest from the architecture-specific URL validated for the release. The Fusion application defaults to `/Applications/VMware Fusion.app`; set `PKR_VAR_vmware_fusion_application_path` to use a different location.
 
 The manually queued ARM64 pipelines are the authoritative end-to-end validation. They require Azure agents advertising `Agent.OS=Darwin`, `Agent.OSArchitecture=ARM64`, and the selected `virtualbox` or `vmware` provider capability, and report the exact macOS, provider, Packer, Packer plugin, Vagrant, Vagrant plugin, and guest-tool versions used by each run.
 
@@ -58,4 +58,4 @@ The canonical `ubuntu-server-2404-lts` box and the `ubuntu-server` alias remain 
 
 Windows 11 uses architecture-dependent editions. The generic `windows-11` alias continues to target Windows 11 25H2 Enterprise on AMD64 and targets Windows 11 25H2 Professional on ARM64. The Professional ARM64 artifact is published truthfully as `windows-11-25h2-professional` and defaults to ARM64 because that canonical box is ARM64-only; the multi-architecture alias remains AMD64 by default.
 
-ARM64 support currently excludes Hyper-V, QEMU/libvirt, Windows guests on VirtualBox, and Intel Macs. Additional image and provider combinations will be listed here after their native build, Vagrant packaging, publication, and downloaded-box boot gates pass.
+ARM64 support currently excludes Hyper-V, QEMU/libvirt, and Intel Macs. Additional image and provider combinations will be listed here after their native build, Vagrant packaging, publication, and downloaded-box boot gates pass.

--- a/docs/site/arm64.md
+++ b/docs/site/arm64.md
@@ -12,13 +12,16 @@ ARM64 images are native Apple-silicon guest images. They use the same canonical 
 | --- | --- | --- |
 | [Ubuntu Server 24.04 LTS]({{ site.baseurl }}{% link images/ubuntu-server/2404-lts/index.md %}) | ARM64 | VirtualBox, VMware |
 | [Ubuntu Server 22.04 LTS]({{ site.baseurl }}{% link images/ubuntu-server/2204-lts/index.md %}) | ARM64 | VirtualBox, VMware |
+| Windows 11 Version 25H2 Professional | ARM64 | VMware |
 
 ### Prerequisites
 
 - An Apple-silicon Mac running the latest stable macOS release
 - The latest stable VirtualBox release, or the latest stable VMware Fusion release and VMware Utility
 - The latest stable Packer and Vagrant releases, including the provider's Packer and Vagrant plugins
-- Sufficient free disk space for the Ubuntu installation ISO, native image, and Vagrant box
+- Sufficient free disk space for the installation ISO, native image, and Vagrant box
+
+Windows builds require the manually downloaded Windows 11 25H2 ARM64 installation ISO. VMware builds obtain the required ARM64 `vmxnet3` boot driver from `drivers-arm64.zip` in the configured VMware Fusion application and download VMware Tools inside the guest from the architecture-specific URL validated for the release. The Fusion application defaults to `/Applications/VMware Fusion.app`; set `PKR_VAR_vmware_fusion_application_path` to use a different location.
 
 The manually queued ARM64 pipelines are the authoritative end-to-end validation. They require Azure agents advertising `Agent.OS=Darwin`, `Agent.OSArchitecture=ARM64`, and the selected `virtualbox` or `vmware` provider capability, and report the exact macOS, provider, Packer, Packer plugin, Vagrant, Vagrant plugin, and guest-tool versions used by each run.
 
@@ -35,4 +38,6 @@ Start the machine with an existing provider identity, for example `vagrant up --
 
 The canonical `ubuntu-server-2404-lts` box and the `ubuntu-server` alias remain AMD64 by default for compatibility. ARM64 publication adds an architecture-specific artifact under the normal catalog release version.
 
-ARM64 support currently excludes Hyper-V, QEMU/libvirt, Windows guests, and Intel Macs. Additional image and provider combinations will be listed here after their native build, Vagrant packaging, publication, and downloaded-box boot gates pass.
+Windows 11 uses architecture-dependent editions. The generic `windows-11` alias continues to target Windows 11 25H2 Enterprise on AMD64 and targets Windows 11 25H2 Professional on ARM64. The Professional ARM64 artifact is published truthfully as `windows-11-25h2-professional` and defaults to ARM64 because that canonical box is ARM64-only; the multi-architecture alias remains AMD64 by default.
+
+ARM64 support currently excludes Hyper-V, QEMU/libvirt, Windows guests on VirtualBox, and Intel Macs. Additional image and provider combinations will be listed here after their native build, Vagrant packaging, publication, and downloaded-box boot gates pass.

--- a/docs/site/arm64.md
+++ b/docs/site/arm64.md
@@ -19,6 +19,8 @@ ARM64 images are native Apple-silicon guest images. They use the same canonical 
 | [Docker on Ubuntu 24.04]({{ site.baseurl }}{% link images/docker/ubuntu-2404/index.md %}) | ARM64 | VirtualBox, VMware |
 | [Kitchen on Ubuntu 24.04]({{ site.baseurl }}{% link images/kitchen/ubuntu-2404/index.md %}) | ARM64 | VirtualBox, VMware |
 | [Kitchen on Ubuntu 22.04]({{ site.baseurl }}{% link images/kitchen/ubuntu-2204/index.md %}) | ARM64 | VirtualBox, VMware |
+| [Development on Ubuntu 24.04]({{ site.baseurl }}{% link images/development/ubuntu-2404/index.md %}) | ARM64 | VirtualBox, VMware |
+| [Development on Ubuntu 22.04]({{ site.baseurl }}{% link images/development/ubuntu-2204/index.md %}) | ARM64 | VirtualBox, VMware |
 | Windows 11 Version 25H2 Professional | ARM64 | VMware |
 
 ### Ubuntu Desktop release components

--- a/docs/site/images/ubuntu-server/2404-lts/index.md
+++ b/docs/site/images/ubuntu-server/2404-lts/index.md
@@ -7,6 +7,8 @@ title: Ubuntu Server 24.04 LTS
 
 [Downloads][BoxOverview]
 
+Available for AMD64 on Hyper-V, QEMU/libvirt, VirtualBox, and VMware, and for ARM64 on VMware. See [ARM64 Support]({{ site.baseurl }}{% link arm64.md %}) for host prerequisites and architecture selection.
+
 This box has the following contents:
 
 - Ubuntu Server 24.04 LTS

--- a/docs/site/images/ubuntu-server/2404-lts/index.md
+++ b/docs/site/images/ubuntu-server/2404-lts/index.md
@@ -7,8 +7,6 @@ title: Ubuntu Server 24.04 LTS
 
 [Downloads][BoxOverview]
 
-Available for AMD64 on Hyper-V, QEMU/libvirt, VirtualBox, and VMware, and for ARM64 on VMware. See [ARM64 Support]({{ site.baseurl }}{% link arm64.md %}) for host prerequisites and architecture selection.
-
 This box has the following contents:
 
 - Ubuntu Server 24.04 LTS

--- a/docs/site/images/ubuntu-server/latest/index.md
+++ b/docs/site/images/ubuntu-server/latest/index.md
@@ -7,8 +7,6 @@ title: Ubuntu Server Latest
 
 [Downloads][BoxOverview]
 
-This alias resolves to Ubuntu Server 24.04 LTS for both AMD64 and ARM64. ARM64 is currently available on VMware and must be selected explicitly; see [ARM64 Support]({{ site.baseurl }}{% link arm64.md %}).
-
 This box is an alias of [Ubuntu Server 24.04 LTS]({{ site.baseurl }}{% link images/ubuntu-server/2404-lts/index.md %}#in-the-box).
 
 [BoxOverview]: https://portal.cloud.hashicorp.com/vagrant/discover/gusztavvargadr/ubuntu-server

--- a/docs/site/images/ubuntu-server/latest/index.md
+++ b/docs/site/images/ubuntu-server/latest/index.md
@@ -7,6 +7,8 @@ title: Ubuntu Server Latest
 
 [Downloads][BoxOverview]
 
+This alias resolves to Ubuntu Server 24.04 LTS for both AMD64 and ARM64. ARM64 is currently available on VMware and must be selected explicitly; see [ARM64 Support]({{ site.baseurl }}{% link arm64.md %}).
+
 This box is an alias of [Ubuntu Server 24.04 LTS]({{ site.baseurl }}{% link images/ubuntu-server/2404-lts/index.md %}#in-the-box).
 
 [BoxOverview]: https://portal.cloud.hashicorp.com/vagrant/discover/gusztavvargadr/ubuntu-server

--- a/docs/site/images/windows-11/25h2-professional/index.md
+++ b/docs/site/images/windows-11/25h2-professional/index.md
@@ -1,0 +1,34 @@
+---
+layout: page
+title: Windows 11 Version 25H2 Professional
+---
+
+### In the box
+
+[Downloads][BoxOverview]
+
+This ARM64 box has the following contents:
+
+- Windows 11 Version 25H2 Professional
+- OpenSSH Server and WinRM
+- Windows Updates disabled
+- Maintenance tasks disabled
+- Windows Defender disabled
+- UAC disabled
+- Generalized with Sysprep
+- User `vagrant` with password `vagrant` and Vagrant's default SSH key
+- 2 CPUs, 4 GB RAM
+
+It is available for VirtualBox and VMware on Apple-silicon Macs and defaults to ARM64.
+
+[BoxOverview]: https://portal.cloud.hashicorp.com/vagrant/discover/gusztavvargadr/windows-11-25h2-professional
+
+### Versions
+
+#### 2607.1.0
+
+[Downloads][BoxVersion260710]
+
+This is the first ARM64 release of Windows 11 Version 25H2 Professional.
+
+[BoxVersion260710]: https://portal.cloud.hashicorp.com/vagrant/discover/gusztavvargadr/windows-11-25h2-professional/versions/2607.1.0

--- a/docs/site/images/windows-11/index.md
+++ b/docs/site/images/windows-11/index.md
@@ -8,6 +8,7 @@ The following images are available:
 - [Windows 11 Latest]({{ site.baseurl }}{% link images/windows-11/latest/index.md %})
 
 - [Windows 11 Version 25H2 Enterprise]({{ site.baseurl }}{% link images/windows-11/25h2-enterprise/index.md %})
+- [Windows 11 Version 25H2 Professional]({{ site.baseurl }}{% link images/windows-11/25h2-professional/index.md %})
 - [Windows 11 Version 24H2 Enterprise]({{ site.baseurl }}{% link images/windows-11/24h2-enterprise/index.md %})
 - [Windows 11 Version 23H2 Enterprise]({{ site.baseurl }}{% link images/windows-11/23h2-enterprise/index.md %})
 - [~~Windows 11 Version 22H2 Enterprise~~]({{ site.baseurl }}{% link images/windows-11/22h2-enterprise/index.md %})

--- a/docs/site/images/windows-11/latest/index.md
+++ b/docs/site/images/windows-11/latest/index.md
@@ -7,17 +7,25 @@ title: Windows 11 Latest
 
 [Downloads][BoxOverview]
 
-This box is an alias of [Windows 11 Version 25H2 Enterprise]({{ site.baseurl }}{% link images/windows-11/25h2-enterprise/index.md %}#in-the-box).
+This box selects [Windows 11 Version 25H2 Enterprise]({{ site.baseurl }}{% link images/windows-11/25h2-enterprise/index.md %}#in-the-box) on AMD64 and [Windows 11 Version 25H2 Professional]({{ site.baseurl }}{% link images/windows-11/25h2-professional/index.md %}#in-the-box) on ARM64.
 
 [BoxOverview]: https://portal.cloud.hashicorp.com/vagrant/discover/gusztavvargadr/windows-11
 
 ### Versions
 
+#### 2607.1.0
+
+[Downloads][BoxVersion260710]
+
+On ARM64, this version is an alias of [Windows 11 Version 25H2 Professional 2607.1.0]({{ site.baseurl }}{% link images/windows-11/25h2-professional/index.md %}#260710).
+
+[BoxVersion260710]: https://portal.cloud.hashicorp.com/vagrant/discover/gusztavvargadr/windows-11/versions/2607.1.0
+
 #### 2601.0.0
 
 [Downloads][BoxVersion260100]
 
-This version is an alias of [Windows 11 Version 25H2 Enterprise 2601.0.0]({{ site.baseurl }}{% link images/windows-11/25h2-enterprise/index.md %}#260100).
+On AMD64, this version is an alias of [Windows 11 Version 25H2 Enterprise 2601.0.0]({{ site.baseurl }}{% link images/windows-11/25h2-enterprise/index.md %}#260100).
 
 [BoxVersion260100]: https://portal.cloud.hashicorp.com/vagrant/discover/gusztavvargadr/windows-11/versions/2601.0.0
 
@@ -25,6 +33,6 @@ This version is an alias of [Windows 11 Version 25H2 Enterprise 2601.0.0]({{ sit
 
 [Downloads][BoxVersion251100]
 
-This version is an alias of [Windows 11 Version 25H2 Enterprise 2511.0.0]({{ site.baseurl }}{% link images/windows-11/25h2-enterprise/index.md %}#251100).
+On AMD64, this version is an alias of [Windows 11 Version 25H2 Enterprise 2511.0.0]({{ site.baseurl }}{% link images/windows-11/25h2-enterprise/index.md %}#251100).
 
 [BoxVersion251100]: https://portal.cloud.hashicorp.com/vagrant/discover/gusztavvargadr/windows-11/versions/2511.0.0

--- a/samples/core.Vagrantfile
+++ b/samples/core.Vagrantfile
@@ -19,10 +19,5 @@ def config_vm_define(config, vm_name, box_name, box_architecture = nil)
     config.vm.box = box
     config.vm.box_url = box_url unless box_url.empty?
     config.vm.box_architecture = box_architecture unless box_architecture.nil?
-
-    config.trigger.after :destroy do |trigger|
-      trigger.info = "Deleting box"
-      trigger.run = { inline: "vagrant box remove #{box} --all"}
-    end
   end
 end

--- a/samples/core.Vagrantfile
+++ b/samples/core.Vagrantfile
@@ -7,7 +7,7 @@ Vagrant.configure("2") do |config|
   config.vm.synced_folder ".", "/vagrant", disabled: true
 end
 
-def config_vm_define(config, vm_name, box_name)
+def config_vm_define(config, vm_name, box_name, box_architecture = nil)
   box_author = ENV["VAGRANT_BOX_AUTHOR"] || "gusztavvargadr"
   box_author = box_author.to_s.strip
   box_url = ENV["VAGRANT_BOX_URL"]
@@ -18,6 +18,7 @@ def config_vm_define(config, vm_name, box_name)
   config.vm.define vm_name, autostart: false do |config|
     config.vm.box = box
     config.vm.box_url = box_url unless box_url.empty?
+    config.vm.box_architecture = box_architecture unless box_architecture.nil?
 
     config.trigger.after :destroy do |trigger|
       trigger.info = "Deleting box"

--- a/samples/development-ubuntu/Vagrantfile
+++ b/samples/development-ubuntu/Vagrantfile
@@ -14,6 +14,19 @@ Vagrant.configure("2") do |config|
     lscpu
     lsmem
 
+    if [ "$(uname -m)" = "aarch64" ]; then
+      if [ -f /home/vagrant/.vbox_version ]; then
+        echo "VirtualBox Guest Additions are not supported on Ubuntu ARM64 guests."
+      else
+        if ! command -v vmware-toolbox-cmd >/dev/null; then
+          echo "VMware guest tools are not installed."
+          exit 1
+        fi
+
+        vmware-toolbox-cmd -v
+      fi
+    fi
+
     apt list --installed
 
     git --version

--- a/samples/development-ubuntu/Vagrantfile
+++ b/samples/development-ubuntu/Vagrantfile
@@ -14,19 +14,6 @@ Vagrant.configure("2") do |config|
     lscpu
     lsmem
 
-    if [ "$(uname -m)" = "aarch64" ]; then
-      if [ -f /home/vagrant/.vbox_version ]; then
-        echo "VirtualBox Guest Additions are not supported on Ubuntu ARM64 guests."
-      else
-        if ! command -v vmware-toolbox-cmd >/dev/null; then
-          echo "VMware guest tools are not installed."
-          exit 1
-        fi
-
-        vmware-toolbox-cmd -v
-      fi
-    fi
-
     apt list --installed
 
     git --version

--- a/samples/development-ubuntu/Vagrantfile
+++ b/samples/development-ubuntu/Vagrantfile
@@ -2,7 +2,9 @@ load "#{File.dirname(__FILE__)}/../core.Vagrantfile"
 
 Vagrant.configure("2") do |config|
   config_vm_define config, "2404", "development-ubuntu-2404"
+  config_vm_define config, "2404-arm64", "development-ubuntu-2404", "arm64"
   config_vm_define config, "2204", "development-ubuntu-2204"
+  config_vm_define config, "2204-arm64", "development-ubuntu-2204", "arm64"
 
   config.vm.provision "shell", inline: <<-EOH
     uname -a

--- a/samples/development-ubuntu/images.pkrvars.hcl
+++ b/samples/development-ubuntu/images.pkrvars.hcl
@@ -9,8 +9,25 @@ images = {
     }
 
     vagrant = {
-      cpus      = "4"
-      memory    = "8192"
+      cpus   = "4"
+      memory = "8192"
+    }
+  }
+
+  "2404-arm64" = {
+    core = {
+      architecture      = "arm64"
+      image_description = "Development on Ubuntu 24.04 ARM64"
+    }
+
+    native = {
+      source_image = "ubuntu-desktop/2404-lts-ubuntu-arm64"
+    }
+
+    vagrant = {
+      cpus     = "4"
+      memory   = "8192"
+      box_name = "development-ubuntu-2404"
     }
   }
 
@@ -24,8 +41,25 @@ images = {
     }
 
     vagrant = {
-      cpus      = "4"
-      memory    = "8192"
+      cpus   = "4"
+      memory = "8192"
+    }
+  }
+
+  "2204-arm64" = {
+    core = {
+      architecture      = "arm64"
+      image_description = "Development on Ubuntu 22.04 ARM64"
+    }
+
+    native = {
+      source_image = "ubuntu-desktop/2204-lts-ubuntu-arm64"
+    }
+
+    vagrant = {
+      cpus     = "4"
+      memory   = "8192"
+      box_name = "development-ubuntu-2204"
     }
   }
 }

--- a/samples/docker-linux/Vagrantfile
+++ b/samples/docker-linux/Vagrantfile
@@ -2,6 +2,7 @@ load "#{File.dirname(__FILE__)}/../core.Vagrantfile"
 
 Vagrant.configure("2") do |config|
   config_vm_define config, "community-ubuntu-server", "docker-community-ubuntu-server"
+  config_vm_define config, "community-ubuntu-server-arm64", "docker-community-ubuntu-server", "arm64"
 
   config_vm_define config, "community-ubuntu-server-alias", "docker-linux"
 

--- a/samples/docker-linux/images.pkrvars.hcl
+++ b/samples/docker-linux/images.pkrvars.hcl
@@ -13,4 +13,20 @@ images = {
       box_alias = "docker-linux"
     }
   }
+
+  "community-ubuntu-server-arm64" = {
+    core = {
+      architecture      = "arm64"
+      image_description = "Docker on Ubuntu 24.04 ARM64"
+    }
+
+    native = {
+      source_image = "ubuntu-server/2404-lts-arm64"
+    }
+
+    vagrant = {
+      box_name  = "docker-community-ubuntu-server"
+      box_alias = "docker-linux"
+    }
+  }
 }

--- a/samples/kitchen-ubuntu/Vagrantfile
+++ b/samples/kitchen-ubuntu/Vagrantfile
@@ -2,7 +2,9 @@ load "#{File.dirname(__FILE__)}/../core.Vagrantfile"
 
 Vagrant.configure("2") do |config|
   config_vm_define config, "2404", "kitchen-ubuntu-2404"
+  config_vm_define config, "2404-arm64", "kitchen-ubuntu-2404", "arm64"
   config_vm_define config, "2204", "kitchen-ubuntu-2204"
+  config_vm_define config, "2204-arm64", "kitchen-ubuntu-2204", "arm64"
 
   config.vm.provision "shell", inline: <<-EOH
     uname -a

--- a/samples/kitchen-ubuntu/images.pkrvars.hcl
+++ b/samples/kitchen-ubuntu/images.pkrvars.hcl
@@ -10,6 +10,22 @@ images = {
     }
   }
 
+  "2404-arm64" = {
+    core = {
+      architecture      = "arm64"
+      image_description = "Kitchen on Ubuntu 24.04 ARM64"
+    }
+
+    native = {
+      source_image = "ubuntu-server/2404-lts-arm64"
+      chef_keep    = "true"
+    }
+
+    vagrant = {
+      box_name = "kitchen-ubuntu-2404"
+    }
+  }
+
   "2204" = {
     core = {
       image_description = "Kitchen on Ubuntu 22.04"
@@ -18,6 +34,22 @@ images = {
     native = {
       source_image = "ubuntu-server/2204-lts"
       chef_keep    = "true"
+    }
+  }
+
+  "2204-arm64" = {
+    core = {
+      architecture      = "arm64"
+      image_description = "Kitchen on Ubuntu 22.04 ARM64"
+    }
+
+    native = {
+      source_image = "ubuntu-server/2204-lts-arm64"
+      chef_keep    = "true"
+    }
+
+    vagrant = {
+      box_name = "kitchen-ubuntu-2204"
     }
   }
 }

--- a/samples/ubuntu-desktop/Vagrantfile
+++ b/samples/ubuntu-desktop/Vagrantfile
@@ -21,19 +21,6 @@ Vagrant.configure("2") do |config|
     lscpu
     lsmem
 
-    if [ "$(uname -m)" = "aarch64" ]; then
-      if [ -f /home/vagrant/.vbox_version ]; then
-        echo "VirtualBox Guest Additions are not supported on Ubuntu ARM64 guests."
-      else
-        if ! command -v vmware-toolbox-cmd >/dev/null; then
-          echo "VMware guest tools are not installed."
-          exit 1
-        fi
-
-        vmware-toolbox-cmd -v
-      fi
-    fi
-
     apt list --installed
   EOH
 end

--- a/samples/ubuntu-desktop/Vagrantfile
+++ b/samples/ubuntu-desktop/Vagrantfile
@@ -2,9 +2,11 @@ load "#{File.dirname(__FILE__)}/../core.Vagrantfile"
 
 Vagrant.configure("2") do |config|
   config_vm_define config, "2404-lts-ubuntu", "ubuntu-desktop-2404-lts"
+  config_vm_define config, "2404-lts-ubuntu-arm64", "ubuntu-desktop-2404-lts", "arm64"
   config_vm_define config, "2404-lts-xubuntu", "xubuntu-desktop-2404-lts"
   config_vm_define config, "2404-lts-xubuntu-arm64", "xubuntu-desktop-2404-lts", "arm64"
   config_vm_define config, "2204-lts-ubuntu", "ubuntu-desktop-2204-lts"
+  config_vm_define config, "2204-lts-ubuntu-arm64", "ubuntu-desktop-2204-lts", "arm64"
   config_vm_define config, "2204-lts-xubuntu", "xubuntu-desktop-2204-lts"
   config_vm_define config, "2204-lts-xubuntu-arm64", "xubuntu-desktop-2204-lts", "arm64"
 

--- a/samples/ubuntu-desktop/Vagrantfile
+++ b/samples/ubuntu-desktop/Vagrantfile
@@ -23,17 +23,7 @@ Vagrant.configure("2") do |config|
 
     if [ "$(uname -m)" = "aarch64" ]; then
       if [ -f /home/vagrant/.vbox_version ]; then
-        if ! command -v VBoxControl >/dev/null; then
-          echo "VirtualBox Guest Additions are not installed."
-          exit 1
-        fi
-
-        host_virtualbox_version="$(cat /home/vagrant/.vbox_version)"
-        guest_additions_version="$(VBoxControl --version | sed 's/r.*//')"
-
-        echo "Host VirtualBox: ${host_virtualbox_version}"
-        echo "VirtualBox Guest Additions: ${guest_additions_version}"
-        test "${guest_additions_version}" = "${host_virtualbox_version}"
+        echo "VirtualBox Guest Additions are not supported on Ubuntu ARM64 guests."
       else
         if ! command -v vmware-toolbox-cmd >/dev/null; then
           echo "VMware guest tools are not installed."

--- a/samples/ubuntu-desktop/Vagrantfile
+++ b/samples/ubuntu-desktop/Vagrantfile
@@ -22,16 +22,24 @@ Vagrant.configure("2") do |config|
     lsmem
 
     if [ "$(uname -m)" = "aarch64" ]; then
-      if command -v VBoxControl >/dev/null; then
+      if [ -f /home/vagrant/.vbox_version ]; then
+        if ! command -v VBoxControl >/dev/null; then
+          echo "VirtualBox Guest Additions are not installed."
+          exit 1
+        fi
+
         host_virtualbox_version="$(cat /home/vagrant/.vbox_version)"
         guest_additions_version="$(VBoxControl --version | sed 's/r.*//')"
 
         echo "Host VirtualBox: ${host_virtualbox_version}"
         echo "VirtualBox Guest Additions: ${guest_additions_version}"
         test "${guest_additions_version}" = "${host_virtualbox_version}"
-      fi
+      else
+        if ! command -v vmware-toolbox-cmd >/dev/null; then
+          echo "VMware guest tools are not installed."
+          exit 1
+        fi
 
-      if command -v vmware-toolbox-cmd >/dev/null; then
         vmware-toolbox-cmd -v
       fi
     fi

--- a/samples/ubuntu-desktop/Vagrantfile
+++ b/samples/ubuntu-desktop/Vagrantfile
@@ -3,8 +3,10 @@ load "#{File.dirname(__FILE__)}/../core.Vagrantfile"
 Vagrant.configure("2") do |config|
   config_vm_define config, "2404-lts-ubuntu", "ubuntu-desktop-2404-lts"
   config_vm_define config, "2404-lts-xubuntu", "xubuntu-desktop-2404-lts"
+  config_vm_define config, "2404-lts-xubuntu-arm64", "xubuntu-desktop-2404-lts", "arm64"
   config_vm_define config, "2204-lts-ubuntu", "ubuntu-desktop-2204-lts"
   config_vm_define config, "2204-lts-xubuntu", "xubuntu-desktop-2204-lts"
+  config_vm_define config, "2204-lts-xubuntu-arm64", "xubuntu-desktop-2204-lts", "arm64"
 
   config_vm_define config, "2404-lts-ubuntu-alias", "ubuntu-desktop"
   config_vm_define config, "2404-lts-xubuntu-alias", "xubuntu-desktop"
@@ -16,6 +18,21 @@ Vagrant.configure("2") do |config|
     lshw -short
     lscpu
     lsmem
+
+    if [ "$(uname -m)" = "aarch64" ]; then
+      if command -v VBoxControl >/dev/null; then
+        host_virtualbox_version="$(cat /home/vagrant/.vbox_version)"
+        guest_additions_version="$(VBoxControl --version | sed 's/r.*//')"
+
+        echo "Host VirtualBox: ${host_virtualbox_version}"
+        echo "VirtualBox Guest Additions: ${guest_additions_version}"
+        test "${guest_additions_version}" = "${host_virtualbox_version}"
+      fi
+
+      if command -v vmware-toolbox-cmd >/dev/null; then
+        vmware-toolbox-cmd -v
+      fi
+    fi
 
     apt list --installed
   EOH

--- a/samples/ubuntu-desktop/images.pkrvars.hcl
+++ b/samples/ubuntu-desktop/images.pkrvars.hcl
@@ -55,6 +55,26 @@ images = {
     }
   }
 
+  "2404-lts-xubuntu-arm64" = {
+    core = {
+      architecture      = "arm64"
+      image_description = "Xubuntu Desktop 24.04 LTS ARM64"
+    }
+
+    native = {
+      source_image = "ubuntu-server/2404-lts-arm64"
+
+      chef_attributes = "xubuntu"
+    }
+
+    vagrant = {
+      memory    = "4096"
+      ports     = "3389"
+      box_name  = "xubuntu-desktop-2404-lts"
+      box_alias = "xubuntu-desktop"
+    }
+  }
+
   "2204-lts-ubuntu" = {
     core = {
       image_description = "Ubuntu Desktop 22.04 LTS"
@@ -67,9 +87,9 @@ images = {
     }
 
     vagrant = {
-      memory    = "4096"
-      ports     = "3389"
-      box_name  = "ubuntu-desktop-2204-lts"
+      memory   = "4096"
+      ports    = "3389"
+      box_name = "ubuntu-desktop-2204-lts"
     }
   }
 
@@ -80,6 +100,25 @@ images = {
 
     native = {
       source_image = "ubuntu-server/2204-lts"
+
+      chef_attributes = "xubuntu"
+    }
+
+    vagrant = {
+      memory   = "4096"
+      ports    = "3389"
+      box_name = "xubuntu-desktop-2204-lts"
+    }
+  }
+
+  "2204-lts-xubuntu-arm64" = {
+    core = {
+      architecture      = "arm64"
+      image_description = "Xubuntu Desktop 22.04 LTS ARM64"
+    }
+
+    native = {
+      source_image = "ubuntu-server/2204-lts-arm64"
 
       chef_attributes = "xubuntu"
     }

--- a/samples/ubuntu-desktop/images.pkrvars.hcl
+++ b/samples/ubuntu-desktop/images.pkrvars.hcl
@@ -50,15 +50,19 @@ images = {
     }
 
     virtualbox = {
-      audio_controller = "none"
-      chipset          = "armv8virtual"
-      gfx_controller   = "qemuramfb"
-      guest_os_type    = "Ubuntu24_LTS_arm64"
-      iso_interface    = "sata"
-      keyboard         = "usb"
-      mouse            = "usb"
-      usb              = "true"
-      usb_controller   = "xhci"
+      audio_controller        = "none"
+      boot_command_key_buffer = "true"
+      boot_keygroup_interval  = "1s"
+      boot_wait               = "10s"
+      chipset                 = "armv8virtual"
+      gfx_controller          = "qemuramfb"
+      guest_os_type           = "Ubuntu24_LTS_arm64"
+      iso_interface           = "sata"
+      keyboard                = "usb"
+      mouse                   = "usb"
+      remove_ide_controller   = "true"
+      usb                     = "true"
+      usb_controller          = "xhci"
     }
 
     vmware = {

--- a/samples/ubuntu-desktop/images.pkrvars.hcl
+++ b/samples/ubuntu-desktop/images.pkrvars.hcl
@@ -28,6 +28,49 @@ images = {
     }
   }
 
+  "2404-lts-ubuntu-arm64" = {
+    core = {
+      architecture      = "arm64"
+      image_description = "Ubuntu Desktop 24.04 LTS ARM64"
+    }
+
+    native = {
+      source_iso_url_local  = "ubuntu-24.04.4-desktop-arm64.iso"
+      source_iso_url_remote = "https://cdimage.ubuntu.com/ubuntu/releases/24.04/release/ubuntu-24.04.4-desktop-arm64.iso"
+      source_iso_checksum   = "sha256:c2610520bf582976839a1724c669e1cfed0547427be5a0ad12d457b92b46ffbe"
+
+      chef_attributes = "ubuntu"
+    }
+
+    vagrant = {
+      memory    = "4096"
+      ports     = "3389"
+      box_name  = "ubuntu-desktop-2404-lts"
+      box_alias = "ubuntu-desktop"
+    }
+
+    virtualbox = {
+      audio_controller = "none"
+      chipset          = "armv8virtual"
+      gfx_controller   = "qemuramfb"
+      guest_os_type    = "Ubuntu24_LTS_arm64"
+      iso_interface    = "sata"
+      keyboard         = "usb"
+      mouse            = "usb"
+      usb              = "true"
+      usb_controller   = "xhci"
+    }
+
+    vmware = {
+      cdrom_adapter_type   = "sata"
+      disk_adapter_type    = "sata"
+      guest_os_type        = "arm-ubuntu-64"
+      network_adapter_type = "e1000e"
+      vmx_svga_autodetect  = "TRUE"
+      vmx_usb_xhci_present = "TRUE"
+    }
+  }
+
   "2404-lts-xubuntu" = {
     core = {
       image_description = "Xubuntu Desktop 24.04 LTS"
@@ -82,6 +125,25 @@ images = {
 
     native = {
       source_image = "ubuntu-server/2204-lts"
+
+      chef_attributes = "ubuntu"
+    }
+
+    vagrant = {
+      memory   = "4096"
+      ports    = "3389"
+      box_name = "ubuntu-desktop-2204-lts"
+    }
+  }
+
+  "2204-lts-ubuntu-arm64" = {
+    core = {
+      architecture      = "arm64"
+      image_description = "Ubuntu Desktop 22.04 LTS ARM64"
+    }
+
+    native = {
+      source_image = "ubuntu-server/2204-lts-arm64"
 
       chef_attributes = "ubuntu"
     }

--- a/samples/ubuntu-server/Vagrantfile
+++ b/samples/ubuntu-server/Vagrantfile
@@ -15,10 +15,6 @@ Vagrant.configure("2") do |config|
     lscpu
     lsmem
 
-    if command -v vmware-toolbox-cmd >/dev/null; then
-      vmware-toolbox-cmd -v
-    fi
-
     apt list --installed
   EOH
 end

--- a/samples/ubuntu-server/Vagrantfile
+++ b/samples/ubuntu-server/Vagrantfile
@@ -2,6 +2,7 @@ load "#{File.dirname(__FILE__)}/../core.Vagrantfile"
 
 Vagrant.configure("2") do |config|
   config_vm_define config, "2404-lts", "ubuntu-server-2404-lts"
+  config_vm_define config, "2404-lts-arm64", "ubuntu-server-2404-lts", "arm64"
   config_vm_define config, "2204-lts", "ubuntu-server-2204-lts"
 
   config_vm_define config, "2404-lts-alias", "ubuntu-server"
@@ -13,6 +14,10 @@ Vagrant.configure("2") do |config|
     lshw -short
     lscpu
     lsmem
+
+    if command -v vmware-toolbox-cmd >/dev/null; then
+      vmware-toolbox-cmd -v
+    fi
 
     apt list --installed
   EOH

--- a/samples/ubuntu-server/Vagrantfile
+++ b/samples/ubuntu-server/Vagrantfile
@@ -16,7 +16,9 @@ Vagrant.configure("2") do |config|
     lscpu
     lsmem
 
-    if command -v VBoxControl >/dev/null; then
+    if [ "$(uname -m)" = "aarch64" ] && [ -f /home/vagrant/.vbox_version ]; then
+      echo "VirtualBox Guest Additions are not supported on Ubuntu ARM64 guests."
+    elif command -v VBoxControl >/dev/null; then
       host_virtualbox_version="$(cat /home/vagrant/.vbox_version)"
       guest_additions_version="$(VBoxControl --version | sed 's/r.*//')"
 

--- a/samples/ubuntu-server/Vagrantfile
+++ b/samples/ubuntu-server/Vagrantfile
@@ -16,21 +16,6 @@ Vagrant.configure("2") do |config|
     lscpu
     lsmem
 
-    if [ "$(uname -m)" = "aarch64" ] && [ -f /home/vagrant/.vbox_version ]; then
-      echo "VirtualBox Guest Additions are not supported on Ubuntu ARM64 guests."
-    elif command -v VBoxControl >/dev/null; then
-      host_virtualbox_version="$(cat /home/vagrant/.vbox_version)"
-      guest_additions_version="$(VBoxControl --version | sed 's/r.*//')"
-
-      echo "Host VirtualBox: ${host_virtualbox_version}"
-      echo "VirtualBox Guest Additions: ${guest_additions_version}"
-      test "${guest_additions_version}" = "${host_virtualbox_version}"
-    fi
-
-    if command -v vmware-toolbox-cmd >/dev/null; then
-      vmware-toolbox-cmd -v
-    fi
-
     apt list --installed
   EOH
 end

--- a/samples/ubuntu-server/Vagrantfile
+++ b/samples/ubuntu-server/Vagrantfile
@@ -4,6 +4,7 @@ Vagrant.configure("2") do |config|
   config_vm_define config, "2404-lts", "ubuntu-server-2404-lts"
   config_vm_define config, "2404-lts-arm64", "ubuntu-server-2404-lts", "arm64"
   config_vm_define config, "2204-lts", "ubuntu-server-2204-lts"
+  config_vm_define config, "2204-lts-arm64", "ubuntu-server-2204-lts", "arm64"
 
   config_vm_define config, "2404-lts-alias", "ubuntu-server"
 
@@ -14,6 +15,19 @@ Vagrant.configure("2") do |config|
     lshw -short
     lscpu
     lsmem
+
+    if command -v VBoxControl >/dev/null; then
+      host_virtualbox_version="$(cat /home/vagrant/.vbox_version)"
+      guest_additions_version="$(VBoxControl --version | sed 's/r.*//')"
+
+      echo "Host VirtualBox: ${host_virtualbox_version}"
+      echo "VirtualBox Guest Additions: ${guest_additions_version}"
+      test "${guest_additions_version}" = "${host_virtualbox_version}"
+    fi
+
+    if command -v vmware-toolbox-cmd >/dev/null; then
+      vmware-toolbox-cmd -v
+    fi
 
     apt list --installed
   EOH

--- a/samples/ubuntu-server/images.pkrvars.hcl
+++ b/samples/ubuntu-server/images.pkrvars.hcl
@@ -23,6 +23,33 @@ images = {
     }
   }
 
+  "2404-lts-arm64" = {
+    core = {
+      architecture      = "arm64"
+      image_description = "Ubuntu Server 24.04 LTS ARM64"
+    }
+
+    native = {
+      source_iso_url_local  = "ubuntu-24.04.4-live-server-arm64.iso"
+      source_iso_url_remote = "https://cdimage.ubuntu.com/ubuntu/releases/24.04/release/ubuntu-24.04.4-live-server-arm64.iso"
+      source_iso_checksum   = "sha256:9a6ce6d7e66c8abed24d24944570a495caca80b3b0007df02818e13829f27f32"
+    }
+
+    vagrant = {
+      box_alias = "ubuntu-server"
+      box_name  = "ubuntu-server-2404-lts"
+    }
+
+    vmware = {
+      cdrom_adapter_type   = "sata"
+      disk_adapter_type    = "sata"
+      guest_os_type        = "arm-ubuntu-64"
+      network_adapter_type = "e1000e"
+      vmx_svga_autodetect  = "TRUE"
+      vmx_usb_xhci_present = "TRUE"
+    }
+  }
+
   "2204-lts" = {
     core = {
       image_description = "Ubuntu Server 22.04 LTS"

--- a/samples/ubuntu-server/images.pkrvars.hcl
+++ b/samples/ubuntu-server/images.pkrvars.hcl
@@ -40,6 +40,56 @@ images = {
       box_name  = "ubuntu-server-2404-lts"
     }
 
+    virtualbox = {
+      audio_controller = "none"
+      chipset          = "armv8virtual"
+      gfx_controller   = "qemuramfb"
+      guest_os_type    = "Ubuntu24_LTS_arm64"
+      iso_interface    = "sata"
+      keyboard         = "usb"
+      mouse            = "usb"
+      usb              = "true"
+      usb_controller   = "xhci"
+    }
+
+    vmware = {
+      cdrom_adapter_type   = "sata"
+      disk_adapter_type    = "sata"
+      guest_os_type        = "arm-ubuntu-64"
+      network_adapter_type = "e1000e"
+      vmx_svga_autodetect  = "TRUE"
+      vmx_usb_xhci_present = "TRUE"
+    }
+  }
+
+  "2204-lts-arm64" = {
+    core = {
+      architecture      = "arm64"
+      image_description = "Ubuntu Server 22.04 LTS ARM64"
+    }
+
+    native = {
+      source_iso_url_local  = "ubuntu-22.04.5-live-server-arm64.iso"
+      source_iso_url_remote = "https://cdimage.ubuntu.com/ubuntu/releases/22.04/release/ubuntu-22.04.5-live-server-arm64.iso"
+      source_iso_checksum   = "sha256:eafec62cfe760c30cac43f446463e628fada468c2de2f14e0e2bc27295187505"
+    }
+
+    vagrant = {
+      box_name = "ubuntu-server-2204-lts"
+    }
+
+    virtualbox = {
+      audio_controller = "none"
+      chipset          = "armv8virtual"
+      gfx_controller   = "qemuramfb"
+      guest_os_type    = "Ubuntu_arm64"
+      iso_interface    = "sata"
+      keyboard         = "usb"
+      mouse            = "usb"
+      usb              = "true"
+      usb_controller   = "xhci"
+    }
+
     vmware = {
       cdrom_adapter_type   = "sata"
       disk_adapter_type    = "sata"

--- a/samples/ubuntu-server/images.pkrvars.hcl
+++ b/samples/ubuntu-server/images.pkrvars.hcl
@@ -41,15 +41,19 @@ images = {
     }
 
     virtualbox = {
-      audio_controller = "none"
-      chipset          = "armv8virtual"
-      gfx_controller   = "qemuramfb"
-      guest_os_type    = "Ubuntu24_LTS_arm64"
-      iso_interface    = "sata"
-      keyboard         = "usb"
-      mouse            = "usb"
-      usb              = "true"
-      usb_controller   = "xhci"
+      audio_controller        = "none"
+      boot_command_key_buffer = "true"
+      boot_keygroup_interval  = "1s"
+      boot_wait               = "10s"
+      chipset                 = "armv8virtual"
+      gfx_controller          = "qemuramfb"
+      guest_os_type           = "Ubuntu24_LTS_arm64"
+      iso_interface           = "sata"
+      keyboard                = "usb"
+      mouse                   = "usb"
+      remove_ide_controller   = "true"
+      usb                     = "true"
+      usb_controller          = "xhci"
     }
 
     vmware = {
@@ -79,15 +83,19 @@ images = {
     }
 
     virtualbox = {
-      audio_controller = "none"
-      chipset          = "armv8virtual"
-      gfx_controller   = "qemuramfb"
-      guest_os_type    = "Ubuntu_arm64"
-      iso_interface    = "sata"
-      keyboard         = "usb"
-      mouse            = "usb"
-      usb              = "true"
-      usb_controller   = "xhci"
+      audio_controller        = "none"
+      boot_command_key_buffer = "true"
+      boot_keygroup_interval  = "1s"
+      boot_wait               = "10s"
+      chipset                 = "armv8virtual"
+      gfx_controller          = "qemuramfb"
+      guest_os_type           = "Ubuntu_arm64"
+      iso_interface           = "sata"
+      keyboard                = "usb"
+      mouse                   = "usb"
+      remove_ide_controller   = "true"
+      usb                     = "true"
+      usb_controller          = "xhci"
     }
 
     vmware = {

--- a/samples/windows-11/Vagrantfile
+++ b/samples/windows-11/Vagrantfile
@@ -2,7 +2,7 @@ load "#{File.dirname(__FILE__)}/../core.Vagrantfile"
 
 Vagrant.configure("2") do |config|
   config_vm_define config, "25h2-enterprise", "windows-11-25h2-enterprise"
-  config_vm_define config, "25h2-professional-arm64", "windows-11-25h2-professional", "arm64"
+  config_vm_define config, '25h2-professional-arm64', 'windows-11-25h2-professional', 'arm64'
   config_vm_define config, "24h2-enterprise", "windows-11-24h2-enterprise"
   config_vm_define config, "23h2-enterprise", "windows-11-23h2-enterprise"
 

--- a/samples/windows-11/Vagrantfile
+++ b/samples/windows-11/Vagrantfile
@@ -2,13 +2,6 @@ require "open3"
 
 load "#{File.dirname(__FILE__)}/../core.Vagrantfile"
 
-host_virtualbox_version = begin
-  output, status = Open3.capture2e("VBoxManage", "--version")
-  status.success? ? output.strip.sub(/r.*$/, "") : ""
-rescue Errno::ENOENT
-  ""
-end
-
 Vagrant.configure("2") do |config|
   config_vm_define config, "25h2-enterprise", "windows-11-25h2-enterprise"
   config_vm_define config, '25h2-professional-arm64', 'windows-11-25h2-professional', 'arm64'
@@ -19,31 +12,41 @@ Vagrant.configure("2") do |config|
 
   config_vm_define config, "25h2-enterprise-alias", "windows-11"
 
+  config.vm.provider "virtualbox" do |_provider, override|
+    host_virtualbox_version = begin
+      output, status = Open3.capture2e("VBoxManage", "--version")
+      status.success? ? output.strip.sub(/r.*$/, "") : ""
+    rescue Errno::ENOENT
+      ""
+    end
+
+    override.vm.provision "shell", inline: <<-EOH
+      if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") {
+        $vbox_control = "C:/Program Files/Oracle/VirtualBox Guest Additions/VBoxGuest/VBoxControl.exe"
+        if (!(Test-Path $vbox_control)) {
+          throw "VirtualBox Guest Additions are not installed."
+        }
+
+        $host_virtualbox_version = "#{host_virtualbox_version}"
+        if ([string]::IsNullOrWhiteSpace($host_virtualbox_version)) {
+          throw "The host VirtualBox version is not available."
+        }
+
+        $guest_additions_version = ((& $vbox_control -v).Trim() -replace "r.*$", "")
+        Write-Host "Host VirtualBox: $host_virtualbox_version"
+        Write-Host "VirtualBox Guest Additions: $guest_additions_version"
+        if ($guest_additions_version -ne $host_virtualbox_version) {
+          throw "VirtualBox Guest Additions do not match the host VirtualBox version."
+        }
+      }
+    EOH
+  end
+
   config.vm.provision "shell", inline: <<-EOH
     cmd /c ver
 
     systeminfo
     Get-ComputerInfo
-
-    $virtualbox_guest = (Get-CimInstance Win32_ComputerSystem).Manufacturer -match "ORCL|Oracle|innotek|VirtualBox"
-    if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64" -and $virtualbox_guest) {
-      $vbox_control = "C:/Program Files/Oracle/VirtualBox Guest Additions/VBoxGuest/VBoxControl.exe"
-      if (!(Test-Path $vbox_control)) {
-        throw "VirtualBox Guest Additions are not installed."
-      }
-
-      $host_virtualbox_version = "#{host_virtualbox_version}"
-      if ([string]::IsNullOrWhiteSpace($host_virtualbox_version)) {
-        throw "The host VirtualBox version is not available."
-      }
-
-      $guest_additions_version = ((& $vbox_control -v).Trim() -replace "r.*$", "")
-      Write-Host "Host VirtualBox: $host_virtualbox_version"
-      Write-Host "VirtualBox Guest Additions: $guest_additions_version"
-      if ($guest_additions_version -ne $host_virtualbox_version) {
-        throw "VirtualBox Guest Additions do not match the host VirtualBox version."
-      }
-    }
 
     $vmware_toolbox = "C:/Program Files/VMware/VMware Tools/VMwareToolboxCmd.exe"
     if (Test-Path $vmware_toolbox) {

--- a/samples/windows-11/Vagrantfile
+++ b/samples/windows-11/Vagrantfile
@@ -1,5 +1,3 @@
-require "open3"
-
 load "#{File.dirname(__FILE__)}/../core.Vagrantfile"
 
 Vagrant.configure("2") do |config|
@@ -12,46 +10,11 @@ Vagrant.configure("2") do |config|
 
   config_vm_define config, "25h2-enterprise-alias", "windows-11"
 
-  config.vm.provider "virtualbox" do |_provider, override|
-    host_virtualbox_version = begin
-      output, status = Open3.capture2e("VBoxManage", "--version")
-      status.success? ? output.strip.sub(/r.*$/, "") : ""
-    rescue Errno::ENOENT
-      ""
-    end
-
-    override.vm.provision "shell", inline: <<-EOH
-      if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") {
-        $vbox_control = "C:/Program Files/Oracle/VirtualBox Guest Additions/VBoxGuest/VBoxControl.exe"
-        if (!(Test-Path $vbox_control)) {
-          throw "VirtualBox Guest Additions are not installed."
-        }
-
-        $host_virtualbox_version = "#{host_virtualbox_version}"
-        if ([string]::IsNullOrWhiteSpace($host_virtualbox_version)) {
-          throw "The host VirtualBox version is not available."
-        }
-
-        $guest_additions_version = ((& $vbox_control -v).Trim() -replace "r.*$", "")
-        Write-Host "Host VirtualBox: $host_virtualbox_version"
-        Write-Host "VirtualBox Guest Additions: $guest_additions_version"
-        if ($guest_additions_version -ne $host_virtualbox_version) {
-          throw "VirtualBox Guest Additions do not match the host VirtualBox version."
-        }
-      }
-    EOH
-  end
-
   config.vm.provision "shell", inline: <<-EOH
     cmd /c ver
 
     systeminfo
     Get-ComputerInfo
-
-    $vmware_toolbox = "C:/Program Files/VMware/VMware Tools/VMwareToolboxCmd.exe"
-    if (Test-Path $vmware_toolbox) {
-      & $vmware_toolbox -v
-    }
 
     Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
     choco list -i

--- a/samples/windows-11/Vagrantfile
+++ b/samples/windows-11/Vagrantfile
@@ -1,4 +1,13 @@
+require "open3"
+
 load "#{File.dirname(__FILE__)}/../core.Vagrantfile"
+
+host_virtualbox_version = begin
+  output, status = Open3.capture2e("VBoxManage", "--version")
+  status.success? ? output.strip.sub(/r.*$/, "") : ""
+rescue Errno::ENOENT
+  ""
+end
 
 Vagrant.configure("2") do |config|
   config_vm_define config, "25h2-enterprise", "windows-11-25h2-enterprise"
@@ -15,6 +24,26 @@ Vagrant.configure("2") do |config|
 
     systeminfo
     Get-ComputerInfo
+
+    $virtualbox_guest = (Get-CimInstance Win32_ComputerSystem).Manufacturer -match "ORCL|Oracle|innotek|VirtualBox"
+    if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64" -and $virtualbox_guest) {
+      $vbox_control = "C:/Program Files/Oracle/VirtualBox Guest Additions/VBoxGuest/VBoxControl.exe"
+      if (!(Test-Path $vbox_control)) {
+        throw "VirtualBox Guest Additions are not installed."
+      }
+
+      $host_virtualbox_version = "#{host_virtualbox_version}"
+      if ([string]::IsNullOrWhiteSpace($host_virtualbox_version)) {
+        throw "The host VirtualBox version is not available."
+      }
+
+      $guest_additions_version = ((& $vbox_control -v).Trim() -replace "r.*$", "")
+      Write-Host "Host VirtualBox: $host_virtualbox_version"
+      Write-Host "VirtualBox Guest Additions: $guest_additions_version"
+      if ($guest_additions_version -ne $host_virtualbox_version) {
+        throw "VirtualBox Guest Additions do not match the host VirtualBox version."
+      }
+    }
 
     $vmware_toolbox = "C:/Program Files/VMware/VMware Tools/VMwareToolboxCmd.exe"
     if (Test-Path $vmware_toolbox) {

--- a/samples/windows-11/Vagrantfile
+++ b/samples/windows-11/Vagrantfile
@@ -2,6 +2,7 @@ load "#{File.dirname(__FILE__)}/../core.Vagrantfile"
 
 Vagrant.configure("2") do |config|
   config_vm_define config, "25h2-enterprise", "windows-11-25h2-enterprise"
+  config_vm_define config, "25h2-professional-arm64", "windows-11-25h2-professional", "arm64"
   config_vm_define config, "24h2-enterprise", "windows-11-24h2-enterprise"
   config_vm_define config, "23h2-enterprise", "windows-11-23h2-enterprise"
 
@@ -14,6 +15,11 @@ Vagrant.configure("2") do |config|
 
     systeminfo
     Get-ComputerInfo
+
+    $vmware_toolbox = "C:/Program Files/VMware/VMware Tools/VMwareToolboxCmd.exe"
+    if (Test-Path $vmware_toolbox) {
+      & $vmware_toolbox -v
+    }
 
     Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
     choco list -i

--- a/samples/windows-11/images.pkrvars.hcl
+++ b/samples/windows-11/images.pkrvars.hcl
@@ -49,6 +49,19 @@ images = {
       alias_default_architecture = "amd64"
     }
 
+    virtualbox = {
+      audio_controller          = "none"
+      chipset                   = "armv8virtual"
+      guest_additions_reconcile = "true"
+      guest_os_type             = "Windows11_arm64"
+      iso_interface             = "sata"
+      keyboard                  = "usb"
+      mouse                     = "usbtablet"
+      nic_type                  = "usbnet"
+      usb                       = "true"
+      usb_controller            = "xhci"
+    }
+
     vmware = {
       boot_driver_archive           = "Contents/Library/isoimages/arm64/drivers-arm64.zip"
       boot_driver_drive             = "E:"

--- a/samples/windows-11/images.pkrvars.hcl
+++ b/samples/windows-11/images.pkrvars.hcl
@@ -1,4 +1,4 @@
-images = {  
+images = {
   "25h2-enterprise" = {
     core = {
       image_description = "Windows 11 Version 25H2 Enterprise"
@@ -26,6 +26,40 @@ images = {
     }
   }
 
+  "25h2-professional-arm64" = {
+    core = {
+      architecture      = "arm64"
+      image_description = "Windows 11 Version 25H2 Professional ARM64"
+    }
+
+    native = {
+      source_iso_url_local  = "Win11_25H2_English_Arm64_v2.iso"
+      source_iso_url_remote = ""
+      source_iso_checksum   = "sha256:638aa2c88e94385b00f4f178d071e3df0b7d9e335577a83bd533b7f2eb65adf0"
+
+      boot_setup_script = "setup.cmd"
+      boot_image_name   = "Windows 11 Pro"
+    }
+
+    vagrant = {
+      memory                     = "4096"
+      box_alias                  = "windows-11"
+      box_name                   = "windows-11-25h2-professional"
+      default_architecture       = "arm64"
+      alias_default_architecture = "amd64"
+    }
+
+    vmware = {
+      boot_driver_archive           = "Contents/Library/isoimages/arm64/drivers-arm64.zip"
+      boot_driver_drive             = "E:"
+      guest_os_type                 = "arm-windows11-64"
+      network_adapter_pcislotnumber = "160"
+      network_adapter_type          = "vmxnet3"
+      tools_source                  = "https://packages-prod.broadcom.com/tools/releases/13.1.0/windows/arm/VMware-tools-13.1.0-25218885-arm.exe"
+      tools_version                 = "13.1.0"
+    }
+  }
+
   "24h2-enterprise" = {
     core = {
       image_description = "Windows 11 Version 24H2 Enterprise"
@@ -40,7 +74,7 @@ images = {
     }
 
     vagrant = {
-      memory    = "4096"
+      memory = "4096"
     }
 
     virtualbox = {
@@ -66,7 +100,7 @@ images = {
     }
 
     vagrant = {
-      memory    = "4096"
+      memory = "4096"
     }
 
     virtualbox = {

--- a/samples/windows-11/images.pkrvars.hcl
+++ b/samples/windows-11/images.pkrvars.hcl
@@ -51,6 +51,8 @@ images = {
 
     virtualbox = {
       audio_controller          = "none"
+      boot_keygroup_interval    = "1s"
+      boot_wait                 = "10s"
       chipset                   = "armv8virtual"
       guest_additions_reconcile = "true"
       guest_os_type             = "Windows11_arm64"
@@ -58,6 +60,7 @@ images = {
       keyboard                  = "usb"
       mouse                     = "usbtablet"
       nic_type                  = "usbnet"
+      remove_ide_controller     = "true"
       usb                       = "true"
       usb_controller            = "xhci"
     }
@@ -70,6 +73,7 @@ images = {
       network_adapter_type          = "vmxnet3"
       tools_source                  = "https://packages-prod.broadcom.com/tools/releases/13.1.0/windows/arm/VMware-tools-13.1.0-25218885-arm.exe"
       tools_version                 = "13.1.0"
+      vmx_usb_xhci_present          = "TRUE"
     }
   }
 

--- a/src/ubuntu/build.native.pkr.hcl
+++ b/src/ubuntu/build.native.pkr.hcl
@@ -23,8 +23,10 @@ locals {
     qemu       = "qemu.import"
   }
 
-  native_iso          = contains(keys(local.image_options.native), "source_iso_checksum")
-  downloads_directory = "${coalesce(var.userprofile_directory, var.home_directory)}/Downloads"
+  native_iso = contains(keys(local.image_options.native), "source_iso_checksum")
+  # VirtualBox ARM64 can discard the first GRUB key group, so send a sacrificial group before each command.
+  boot_command_key_buffer = local.image_provider == "virtualbox" && local.image_architecture == "arm64" ? join("", [for index in range(32) : " "]) : ""
+  downloads_directory     = "${coalesce(var.userprofile_directory, var.home_directory)}/Downloads"
 
   source_options_native = {
     iso_urls = local.native_iso ? [
@@ -38,10 +40,10 @@ locals {
 
     boot_command = local.native_iso ? [
       "c<wait>",
-      "set gfxpayload=keep<enter><wait>",
-      "linux /casper/vmlinuz quiet autoinstall 'ds=nocloud-net;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/${local.image_provider}/'<enter><wait>",
-      "initrd /casper/initrd<enter><wait>",
-      "boot<enter>wait>",
+      "${local.boot_command_key_buffer}set gfxpayload=keep<enter><wait>",
+      "${local.boot_command_key_buffer}linux /casper/vmlinuz quiet autoinstall 'ds=nocloud-net;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/${local.image_provider}/'<enter><wait>",
+      "${local.boot_command_key_buffer}initrd /casper/initrd<enter><wait>",
+      "${local.boot_command_key_buffer}boot<enter><wait>",
     ] : []
     shutdown_command = "sudo -S shutdown -P now"
   }

--- a/src/ubuntu/build.native.pkr.hcl
+++ b/src/ubuntu/build.native.pkr.hcl
@@ -75,6 +75,10 @@ build {
 
   provisioner "shell" {
     script = "${path.root}/chef/initialize.sh"
+
+    env = {
+      GUEST_ARCHITECTURE = local.image_architecture
+    }
   }
 
   provisioner "file" {

--- a/src/ubuntu/build.native.pkr.hcl
+++ b/src/ubuntu/build.native.pkr.hcl
@@ -75,10 +75,6 @@ build {
 
   provisioner "shell" {
     script = "${path.root}/chef/initialize.sh"
-
-    env = {
-      GUEST_ARCHITECTURE = local.image_architecture
-    }
   }
 
   provisioner "file" {

--- a/src/ubuntu/build.native.pkr.hcl
+++ b/src/ubuntu/build.native.pkr.hcl
@@ -9,6 +9,11 @@ variable "home_directory" {
 }
 
 locals {
+  userprofile_directory_input = var.userprofile_directory
+  home_directory_input        = var.home_directory
+}
+
+locals {
   native_iso_sources = {
     virtualbox = "virtualbox-iso.core"
     vmware     = "vmware-iso.core"
@@ -23,10 +28,8 @@ locals {
     qemu       = "qemu.import"
   }
 
-  native_iso = contains(keys(local.image_options.native), "source_iso_checksum")
-  # VirtualBox ARM64 can discard the first GRUB key group, so send a sacrificial group before each command.
-  boot_command_key_buffer = local.image_provider == "virtualbox" && local.image_architecture == "arm64" ? join("", [for index in range(32) : " "]) : ""
-  downloads_directory     = "${coalesce(var.userprofile_directory, var.home_directory)}/Downloads"
+  native_iso          = contains(keys(local.image_options.native), "source_iso_checksum")
+  downloads_directory = "${coalesce(local.userprofile_directory_input, local.home_directory_input)}/Downloads"
 
   source_options_native = {
     iso_urls = local.native_iso ? [
@@ -40,10 +43,10 @@ locals {
 
     boot_command = local.native_iso ? [
       "c<wait>",
-      "${local.boot_command_key_buffer}set gfxpayload=keep<enter><wait>",
-      "${local.boot_command_key_buffer}linux /casper/vmlinuz quiet autoinstall 'ds=nocloud-net;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/${local.image_provider}/'<enter><wait>",
-      "${local.boot_command_key_buffer}initrd /casper/initrd<enter><wait>",
-      "${local.boot_command_key_buffer}boot<enter><wait>",
+      "set gfxpayload=keep<enter><wait>",
+      "linux /casper/vmlinuz quiet autoinstall 'ds=nocloud-net;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/${local.image_provider}/'<enter><wait>",
+      "initrd /casper/initrd<enter><wait>",
+      "boot<enter><wait>",
     ] : []
     shutdown_command = "sudo -S shutdown -P now"
   }

--- a/src/ubuntu/build.vagrant.pkr.hcl
+++ b/src/ubuntu/build.vagrant.pkr.hcl
@@ -36,13 +36,15 @@ locals {
 
 locals {
   vagrant_options_core = {
-    cpus         = "2"
-    memory       = "2048"
-    ports        = ""
-    architecture = "amd64"
+    cpus   = "2"
+    memory = "2048"
+    ports  = ""
   }
   vagrant_options_image = lookup(local.image_options, "vagrant", {})
   vagrant_options       = merge(local.vagrant_options_core, local.vagrant_options_image)
+
+  vagrant_default_architecture       = lookup(local.vagrant_options, "default_architecture", "amd64")
+  vagrant_alias_default_architecture = lookup(local.vagrant_options, "alias_default_architecture", local.vagrant_default_architecture)
 }
 
 source "file" "Vagrantfile" {
@@ -145,8 +147,8 @@ build {
       box_tag              = "${local.image_author}/${lookup(local.vagrant_options, "box_name", replace(local.image_name, "/", "-"))}"
       version              = local.image_version
       box_checksum         = "SHA256:${split("\t", file("${local.artifacts_directory}/checksum.sha256"))[0]}"
-      architecture         = local.vagrant_options.architecture
-      default_architecture = local.vagrant_options.architecture
+      architecture         = local.image_architecture
+      default_architecture = local.vagrant_default_architecture
       // no_release           = true
     }
   }
@@ -162,10 +164,10 @@ build {
       post-processor "vagrant-registry" {
         box_tag              = "${local.image_author}/${post-processors.value}"
         version              = local.image_version
-        box_download_url     = "https://vagrantcloud.com/${local.image_author}/boxes/${lookup(local.vagrant_options, "box_name", replace(local.image_name, "/", "-"))}/versions/${local.image_version}/providers/${lookup(local.vagrant_providers, local.image_provider, "")}/${local.vagrant_options.architecture}/vagrant.box"
+        box_download_url     = "https://vagrantcloud.com/${local.image_author}/boxes/${lookup(local.vagrant_options, "box_name", replace(local.image_name, "/", "-"))}/versions/${local.image_version}/providers/${lookup(local.vagrant_providers, local.image_provider, "")}/${local.image_architecture}/vagrant.box"
         box_checksum         = "SHA256:${split("\t", file("${local.artifacts_directory}/checksum.sha256"))[0]}"
-        architecture         = local.vagrant_options.architecture
-        default_architecture = local.vagrant_options.architecture
+        architecture         = local.image_architecture
+        default_architecture = local.vagrant_alias_default_architecture
         // no_release           = true
       }
     }

--- a/src/ubuntu/build.vagrant.pkr.hcl
+++ b/src/ubuntu/build.vagrant.pkr.hcl
@@ -43,6 +43,9 @@ locals {
   vagrant_options_image = lookup(local.image_options, "vagrant", {})
   vagrant_options       = merge(local.vagrant_options_core, local.vagrant_options_image)
 
+  vagrant_box_name      = lookup(local.vagrant_options, "box_name", replace(local.image_name, "/", "-"))
+  vagrant_test_box_name = "${local.image_author}-test/${local.vagrant_box_name}"
+
   vagrant_default_architecture       = lookup(local.vagrant_options, "default_architecture", "amd64")
   vagrant_alias_default_architecture = lookup(local.vagrant_options, "alias_default_architecture", local.vagrant_default_architecture)
 }
@@ -99,12 +102,14 @@ build {
   provisioner "shell-local" {
     inline = [
       "vagrant destroy -f ${var.image}",
+      "vagrant box remove \"${local.vagrant_test_box_name}\" --all",
     ]
 
     valid_exit_codes = [0, 1]
 
     env = {
-      VAGRANT_BOX_URL = "${local.artifacts_directory}/vagrant/vagrant.box"
+      VAGRANT_BOX_AUTHOR = local.image_author
+      VAGRANT_BOX_URL    = "${local.artifacts_directory}/vagrant/vagrant.box"
     }
   }
 
@@ -116,19 +121,22 @@ build {
     max_retries = 1
 
     env = {
-      VAGRANT_BOX_URL = "${local.artifacts_directory}/vagrant/vagrant.box"
+      VAGRANT_BOX_AUTHOR = local.image_author
+      VAGRANT_BOX_URL    = "${local.artifacts_directory}/vagrant/vagrant.box"
     }
   }
 
   provisioner "shell-local" {
     inline = [
       "vagrant destroy -f ${var.image}",
+      "vagrant box remove \"${local.vagrant_test_box_name}\" --all",
     ]
 
     valid_exit_codes = [0, 1]
 
     env = {
-      VAGRANT_BOX_URL = "${local.artifacts_directory}/vagrant/vagrant.box"
+      VAGRANT_BOX_AUTHOR = local.image_author
+      VAGRANT_BOX_URL    = "${local.artifacts_directory}/vagrant/vagrant.box"
     }
   }
 }

--- a/src/ubuntu/build.vagrant.pkr.hcl
+++ b/src/ubuntu/build.vagrant.pkr.hcl
@@ -44,6 +44,7 @@ locals {
   vagrant_options       = merge(local.vagrant_options_core, local.vagrant_options_image)
 
   vagrant_box_name      = lookup(local.vagrant_options, "box_name", replace(local.image_name, "/", "-"))
+  vagrant_box_tag       = "${local.image_author}/${local.vagrant_box_name}"
   vagrant_test_box_name = "${local.image_author}-test/${local.vagrant_box_name}"
 
   vagrant_default_architecture       = lookup(local.vagrant_options, "default_architecture", "amd64")
@@ -101,7 +102,7 @@ build {
 
   provisioner "shell-local" {
     inline = [
-      "vagrant destroy -f ${var.image}",
+      "vagrant destroy -f ${local.image_key}",
       "vagrant box remove \"${local.vagrant_test_box_name}\" --all",
     ]
 
@@ -115,7 +116,7 @@ build {
 
   provisioner "shell-local" {
     inline = [
-      "vagrant up ${var.image} --provider ${lookup(local.vagrant_providers, local.image_provider, "")}",
+      "vagrant up ${local.image_key} --provider ${lookup(local.vagrant_providers, local.image_provider, "")}",
     ]
 
     max_retries = 1
@@ -128,7 +129,7 @@ build {
 
   provisioner "shell-local" {
     inline = [
-      "vagrant destroy -f ${var.image}",
+      "vagrant destroy -f ${local.image_key}",
       "vagrant box remove \"${local.vagrant_test_box_name}\" --all",
     ]
 
@@ -152,7 +153,7 @@ build {
     }
 
     post-processor "vagrant-registry" {
-      box_tag              = "${local.image_author}/${lookup(local.vagrant_options, "box_name", replace(local.image_name, "/", "-"))}"
+      box_tag              = local.vagrant_box_tag
       version              = local.image_version
       box_checksum         = "SHA256:${split("\t", file("${local.artifacts_directory}/checksum.sha256"))[0]}"
       architecture         = local.image_architecture
@@ -189,7 +190,8 @@ build {
 
   provisioner "shell-local" {
     inline = [
-      "vagrant destroy -f ${var.image}",
+      "vagrant destroy -f ${local.image_key}",
+      "vagrant box remove \"${local.vagrant_box_tag}\" --all",
     ]
 
     valid_exit_codes = [0, 1]
@@ -197,7 +199,7 @@ build {
 
   provisioner "shell-local" {
     inline = [
-      "vagrant up ${var.image} --provider ${lookup(local.vagrant_providers, local.image_provider, "")}",
+      "vagrant up ${local.image_key} --provider ${lookup(local.vagrant_providers, local.image_provider, "")}",
     ]
 
     max_retries = 1
@@ -205,7 +207,8 @@ build {
 
   provisioner "shell-local" {
     inline = [
-      "vagrant destroy -f ${var.image}",
+      "vagrant destroy -f ${local.image_key}",
+      "vagrant box remove \"${local.vagrant_box_tag}\" --all",
     ]
 
     valid_exit_codes = [0, 1]

--- a/src/ubuntu/chef/cookbooks/gusztavvargadr_packer_ubuntu/recipes/initialize.rb
+++ b/src/ubuntu/chef/cookbooks/gusztavvargadr_packer_ubuntu/recipes/initialize.rb
@@ -15,9 +15,10 @@ if vbox?
     action :install
   end
 
-  vbox_version = (shell_out('VBoxControl -v').stdout rescue '').strip
+  host_virtualbox_version = ::File.read('/home/vagrant/.vbox_version').strip
+  guest_additions_version = (shell_out('VBoxControl -v').stdout rescue '').strip.split('r').first
 
-  unless vbox_version.include?('7.')
+  unless guest_additions_version == host_virtualbox_version
     bash 'guest-additions' do
       code <<-EOH
         VER="`cat /home/vagrant/.vbox_version`";

--- a/src/ubuntu/chef/cookbooks/gusztavvargadr_packer_ubuntu/recipes/initialize.rb
+++ b/src/ubuntu/chef/cookbooks/gusztavvargadr_packer_ubuntu/recipes/initialize.rb
@@ -9,7 +9,9 @@ if hyperv?
   end
 end
 
-if vbox?
+arm64_guest = node['kernel']['machine'] == 'aarch64'
+
+if vbox? && !arm64_guest
   kernel_version = shell_out('uname -r').stdout.strip
   apt_package [ 'build-essential', 'dkms', "linux-headers-#{kernel_version}" ] do
     action :install

--- a/src/ubuntu/chef/initialize.sh
+++ b/src/ubuntu/chef/initialize.sh
@@ -2,8 +2,6 @@
 
 set -euo pipefail
 
-echo "Guest architecture: ${GUEST_ARCHITECTURE}"
-
 sudo cloud-init status --wait
 
 sudo apt-get update -y

--- a/src/ubuntu/chef/initialize.sh
+++ b/src/ubuntu/chef/initialize.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+echo "Guest architecture: ${GUEST_ARCHITECTURE}"
+
 sudo cloud-init status --wait
 
 sudo apt-get update -y

--- a/src/ubuntu/core.pkr.hcl
+++ b/src/ubuntu/core.pkr.hcl
@@ -29,12 +29,13 @@ variable "build" {
 locals {
   image_options = var.images[var.image]
 
-  image_author      = var.author
-  image_name        = "${basename(path.cwd)}/${var.image}"
-  image_description = local.image_options.core.image_description
-  image_version     = var.version
-  image_provider    = var.provider
-  image_build       = var.build
+  image_author       = var.author
+  image_name         = "${basename(path.cwd)}/${var.image}"
+  image_description  = local.image_options.core.image_description
+  image_architecture = lookup(local.image_options.core, "architecture", "amd64")
+  image_version      = var.version
+  image_provider     = var.provider
+  image_build        = var.build
 
   artifacts_directory = "${path.cwd}/../../artifacts/${local.image_name}/${local.image_provider}/${var.build}"
 }

--- a/src/ubuntu/core.pkr.hcl
+++ b/src/ubuntu/core.pkr.hcl
@@ -27,15 +27,25 @@ variable "build" {
 }
 
 locals {
-  image_options = var.images[var.image]
+  image_catalog_input  = var.images
+  image_key_input      = var.image
+  image_author_input   = var.author
+  image_version_input  = var.version
+  image_provider_input = var.provider
+  image_build_input    = var.build
+}
 
-  image_author       = var.author
-  image_name         = "${basename(path.cwd)}/${var.image}"
+locals {
+  image_options = local.image_catalog_input[local.image_key_input]
+
+  image_key          = local.image_key_input
+  image_author       = local.image_author_input
+  image_name         = "${basename(path.cwd)}/${local.image_key}"
   image_description  = local.image_options.core.image_description
   image_architecture = lookup(local.image_options.core, "architecture", "amd64")
-  image_version      = var.version
-  image_provider     = var.provider
-  image_build        = var.build
+  image_version      = local.image_version_input
+  image_provider     = local.image_provider_input
+  image_build        = local.image_build_input
 
-  artifacts_directory = "${path.cwd}/../../artifacts/${local.image_name}/${local.image_provider}/${var.build}"
+  artifacts_directory = "${path.cwd}/../../artifacts/${local.image_name}/${local.image_provider}/${local.image_build}"
 }

--- a/src/ubuntu/core.pkr.hcl
+++ b/src/ubuntu/core.pkr.hcl
@@ -32,7 +32,7 @@ locals {
   image_author      = var.author
   image_name        = "${basename(path.cwd)}/${var.image}"
   image_description = local.image_options.core.image_description
-  image_version     = contains(keys(local.image_options.core), "image_version") ? "${local.image_options.core.image_version}.${var.version}" : "${var.version}.0.0"
+  image_version     = var.version
   image_provider    = var.provider
   image_build       = var.build
 

--- a/src/ubuntu/source.hyperv.pkr.hcl
+++ b/src/ubuntu/source.hyperv.pkr.hcl
@@ -13,13 +13,17 @@ variable "hyperv_switch" {
 }
 
 locals {
+  hyperv_switch_input = var.hyperv_switch
+}
+
+locals {
   hyperv_source_options = {
     generation                       = 2
     configuration_version            = "10.0"
     enable_virtualization_extensions = false
     enable_dynamic_memory            = false
     enable_secure_boot               = false
-    switch_name                      = var.hyperv_switch
+    switch_name                      = local.hyperv_switch_input
     enable_mac_spoofing              = true
     disk_block_size                  = "1"
     guest_additions_mode             = "disable"

--- a/src/ubuntu/source.virtualbox.pkr.hcl
+++ b/src/ubuntu/source.virtualbox.pkr.hcl
@@ -1,7 +1,7 @@
 packer {
   required_plugins {
     virtualbox = {
-      version = "~> 1.1"
+      version = "~> 1.1.4"
       source  = "github.com/hashicorp/virtualbox"
     }
   }
@@ -9,13 +9,21 @@ packer {
 
 locals {
   virtualbox_source_options = {
-    guest_additions_mode = "disable"
+    audio_controller     = "ac97"
+    chipset              = "piix3"
     firmware             = "efi"
-    nested_virt          = false
-    hard_drive_interface = "sata"
     gfx_controller       = "vmsvga"
     gfx_vram_size        = 128
+    guest_additions_mode = "disable"
+    hard_drive_interface = "sata"
+    iso_interface        = "ide"
+    keyboard             = "ps2"
+    mouse                = "ps2"
+    nested_virt          = false
+    nic_type             = "82540EM"
     post_shutdown_delay  = "15s"
+    usb                  = false
+    usb_controller       = "ehci"
   }
 }
 
@@ -35,13 +43,21 @@ source "virtualbox-iso" "core" {
   iso_checksum   = local.virtualbox_iso_source_options.iso_checksum
   http_directory = local.virtualbox_iso_source_options.http_directory
 
-  guest_os_type        = local.virtualbox_iso_source_options.guest_os_type
-  guest_additions_mode = local.virtualbox_iso_source_options.guest_additions_mode
+  audio_controller     = local.virtualbox_iso_source_options.audio_controller
+  chipset              = local.virtualbox_iso_source_options.chipset
   firmware             = local.virtualbox_iso_source_options.firmware
-  nested_virt          = local.virtualbox_iso_source_options.nested_virt
-  hard_drive_interface = local.virtualbox_iso_source_options.hard_drive_interface
   gfx_controller       = local.virtualbox_iso_source_options.gfx_controller
   gfx_vram_size        = local.virtualbox_iso_source_options.gfx_vram_size
+  guest_additions_mode = local.virtualbox_iso_source_options.guest_additions_mode
+  guest_os_type        = local.virtualbox_iso_source_options.guest_os_type
+  hard_drive_interface = local.virtualbox_iso_source_options.hard_drive_interface
+  iso_interface        = local.virtualbox_iso_source_options.iso_interface
+  keyboard             = local.virtualbox_iso_source_options.keyboard
+  mouse                = local.virtualbox_iso_source_options.mouse
+  nested_virt          = local.virtualbox_iso_source_options.nested_virt
+  nic_type             = local.virtualbox_iso_source_options.nic_type
+  usb                  = local.virtualbox_iso_source_options.usb
+  usb_controller       = local.virtualbox_iso_source_options.usb_controller
 
   boot_command     = local.virtualbox_iso_source_options.boot_command
   boot_wait        = local.virtualbox_iso_source_options.boot_wait

--- a/src/ubuntu/source.virtualbox.pkr.hcl
+++ b/src/ubuntu/source.virtualbox.pkr.hcl
@@ -28,8 +28,15 @@ locals {
 }
 
 locals {
-  virtualbox_iso_source_options = merge(local.source_options_build, local.virtualbox_source_options, lookup(local.image_options, "virtualbox", {}))
-  virtualbox_iso_arm64          = local.image_architecture == "arm64"
+  virtualbox_image_options = lookup(local.image_options, "virtualbox", {})
+
+  virtualbox_boot_command_key_buffer = lookup(local.virtualbox_image_options, "boot_command_key_buffer", "false") == "true" ? join("", [for index in range(32) : " "]) : ""
+  virtualbox_remove_ide_controller   = lookup(local.virtualbox_image_options, "remove_ide_controller", "false") == "true"
+
+  virtualbox_iso_source_options = merge(local.source_options_build, local.virtualbox_source_options, local.virtualbox_image_options)
+  virtualbox_iso_boot_command = [
+    for index, command in local.virtualbox_iso_source_options.boot_command : index == 0 ? command : "${local.virtualbox_boot_command_key_buffer}${command}"
+  ]
 }
 
 source "virtualbox-iso" "core" {
@@ -60,14 +67,14 @@ source "virtualbox-iso" "core" {
   usb                  = local.virtualbox_iso_source_options.usb
   usb_controller       = local.virtualbox_iso_source_options.usb_controller
 
-  # The plugin creates an unused IDE controller which VirtualBox cannot assign on ARM64.
-  vboxmanage = local.virtualbox_iso_arm64 ? [
+  # Remove the plugin-created IDE controller when the selected image cannot assign it.
+  vboxmanage = local.virtualbox_remove_ide_controller ? [
     ["storagectl", "{{.Name}}", "--name", "IDE", "--remove"]
   ] : []
 
-  boot_command           = local.virtualbox_iso_source_options.boot_command
-  boot_keygroup_interval = local.virtualbox_iso_arm64 ? "1s" : "100ms"
-  boot_wait              = local.virtualbox_iso_arm64 ? "10s" : local.virtualbox_iso_source_options.boot_wait
+  boot_command           = local.virtualbox_iso_boot_command
+  boot_keygroup_interval = lookup(local.virtualbox_image_options, "boot_keygroup_interval", "100ms")
+  boot_wait              = local.virtualbox_iso_source_options.boot_wait
   shutdown_command       = local.virtualbox_iso_source_options.shutdown_command
   shutdown_timeout       = local.virtualbox_iso_source_options.shutdown_timeout
 
@@ -78,7 +85,7 @@ source "virtualbox-iso" "core" {
 }
 
 locals {
-  virtualbox_ovf_source_options = merge(local.source_options_build, local.virtualbox_source_options, lookup(local.image_options, "virtualbox", {}))
+  virtualbox_ovf_source_options = merge(local.source_options_build, local.virtualbox_source_options, local.virtualbox_image_options)
 }
 
 source "virtualbox-ovf" "core" {

--- a/src/ubuntu/source.virtualbox.pkr.hcl
+++ b/src/ubuntu/source.virtualbox.pkr.hcl
@@ -29,6 +29,7 @@ locals {
 
 locals {
   virtualbox_iso_source_options = merge(local.source_options_build, local.virtualbox_source_options, lookup(local.image_options, "virtualbox", {}))
+  virtualbox_iso_arm64          = local.image_architecture == "arm64"
 }
 
 source "virtualbox-iso" "core" {
@@ -59,10 +60,16 @@ source "virtualbox-iso" "core" {
   usb                  = local.virtualbox_iso_source_options.usb
   usb_controller       = local.virtualbox_iso_source_options.usb_controller
 
-  boot_command     = local.virtualbox_iso_source_options.boot_command
-  boot_wait        = local.virtualbox_iso_source_options.boot_wait
-  shutdown_command = local.virtualbox_iso_source_options.shutdown_command
-  shutdown_timeout = local.virtualbox_iso_source_options.shutdown_timeout
+  # The plugin creates an unused IDE controller which VirtualBox cannot assign on ARM64.
+  vboxmanage = local.virtualbox_iso_arm64 ? [
+    ["storagectl", "{{.Name}}", "--name", "IDE", "--remove"]
+  ] : []
+
+  boot_command           = local.virtualbox_iso_source_options.boot_command
+  boot_keygroup_interval = local.virtualbox_iso_arm64 ? "1s" : "100ms"
+  boot_wait              = local.virtualbox_iso_arm64 ? "10s" : local.virtualbox_iso_source_options.boot_wait
+  shutdown_command       = local.virtualbox_iso_source_options.shutdown_command
+  shutdown_timeout       = local.virtualbox_iso_source_options.shutdown_timeout
 
   communicator = local.communicator.type
   ssh_username = local.communicator.username

--- a/src/ubuntu/source.vmware.pkr.hcl
+++ b/src/ubuntu/source.vmware.pkr.hcl
@@ -13,15 +13,25 @@ locals {
     disk_type_id      = 0
     disk_adapter_type = "nvme"
     vmx_data = {
-      firmware        = "efi"
-      "vhv.enable"    = "FALSE"
+      firmware     = "efi"
+      "vhv.enable" = "FALSE"
     }
     vmx_remove_ethernet_interfaces = local.native_build ? false : true
   }
 }
 
 locals {
-  vmware_iso_source_options = merge(local.source_options_build, local.vmware_source_options, lookup(local.image_options, "vmware", {}))
+  vmware_image_options = lookup(local.image_options, "vmware", {})
+  vmware_image_vmx_data = {
+    for key, value in {
+      "svga.autodetect"  = lookup(local.vmware_image_options, "vmx_svga_autodetect", "")
+      "usb_xhci.present" = lookup(local.vmware_image_options, "vmx_usb_xhci_present", "")
+    } : key => value if value != ""
+  }
+
+  vmware_iso_source_options = merge(local.source_options_build, local.vmware_source_options, local.vmware_image_options, {
+    vmx_data = merge(local.vmware_source_options.vmx_data, local.vmware_image_vmx_data)
+  })
 }
 
 source "vmware-iso" "core" {
@@ -40,6 +50,8 @@ source "vmware-iso" "core" {
   guest_os_type                  = local.vmware_iso_source_options.guest_os_type
   disk_type_id                   = local.vmware_iso_source_options.disk_type_id
   disk_adapter_type              = local.vmware_iso_source_options.disk_adapter_type
+  cdrom_adapter_type             = try(local.vmware_iso_source_options.cdrom_adapter_type, null)
+  network_adapter_type           = try(local.vmware_iso_source_options.network_adapter_type, null)
   vmx_data                       = local.vmware_iso_source_options.vmx_data
   vmx_remove_ethernet_interfaces = local.vmware_iso_source_options.vmx_remove_ethernet_interfaces
 
@@ -48,14 +60,14 @@ source "vmware-iso" "core" {
   shutdown_command = local.vmware_iso_source_options.shutdown_command
   shutdown_timeout = local.vmware_iso_source_options.shutdown_timeout
 
-  communicator   = local.communicator.type
-  ssh_username   = local.communicator.username
-  ssh_password   = local.communicator.password
-  ssh_timeout    = local.communicator.timeout
+  communicator = local.communicator.type
+  ssh_username = local.communicator.username
+  ssh_password = local.communicator.password
+  ssh_timeout  = local.communicator.timeout
 }
 
 locals {
-  vmware_vmx_source_options = merge(local.source_options_build, local.vmware_source_options, lookup(local.image_options, "vmware", {}))
+  vmware_vmx_source_options = merge(local.source_options_build, local.vmware_source_options, local.vmware_image_options)
 }
 
 source "vmware-vmx" "core" {
@@ -72,8 +84,8 @@ source "vmware-vmx" "core" {
   shutdown_command = local.vmware_vmx_source_options.shutdown_command
   shutdown_timeout = local.vmware_vmx_source_options.shutdown_timeout
 
-  communicator   = local.communicator.type
-  ssh_username   = local.communicator.username
-  ssh_password   = local.communicator.password
-  ssh_timeout    = local.communicator.timeout
+  communicator = local.communicator.type
+  ssh_username = local.communicator.username
+  ssh_password = local.communicator.password
+  ssh_timeout  = local.communicator.timeout
 }

--- a/src/ubuntu/source.vmware.pkr.hcl
+++ b/src/ubuntu/source.vmware.pkr.hcl
@@ -13,8 +13,7 @@ locals {
     disk_type_id      = 0
     disk_adapter_type = "nvme"
     vmx_data = {
-      firmware     = "efi"
-      "vhv.enable" = "FALSE"
+      firmware = "efi"
     }
     vmx_remove_ethernet_interfaces = local.native_build ? false : true
   }

--- a/src/windows/boot/autounattend-first-logon.ps1
+++ b/src/windows/boot/autounattend-first-logon.ps1
@@ -2,6 +2,13 @@ Write-Host "Configure PowerShell"
 $ProgressPreference = 'SilentlyContinue'
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
+%{ for boot_driver_drive in compact([lookup(provider, "boot_driver_drive", "")]) ~}
+Write-Host "Install Boot Drivers"
+Push-Location ${boot_driver_drive}\
+pnputil /add-driver *.inf /install /subdirs
+Pop-Location
+
+%{ endfor ~}
 Write-Host "Install Chocolatey"
 %{ for chocolatey_version in compact([lookup(boot, "boot_chocolatey_version", "2.7.3")]) ~}
 $env:chocolateyVersion = '${chocolatey_version}'

--- a/src/windows/boot/autounattend.xml
+++ b/src/windows/boot/autounattend.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <unattend xmlns="urn:schemas-microsoft-com:unattend">
     <settings pass="windowsPE">
-        <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="${architecture}" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <SetupUILanguage>
                 <UILanguage>en-US</UILanguage>
             </SetupUILanguage>
@@ -11,7 +11,7 @@
             <UILanguageFallback>en-US</UILanguageFallback>
             <UserLocale>en-US</UserLocale>
         </component>
-        <component name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <component name="Microsoft-Windows-Setup" processorArchitecture="${architecture}" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 %{ for setup_script in compact([lookup(boot, "boot_setup_script", "")]) ~}
             <RunSynchronous>
                 <RunSynchronousCommand wcm:action="add">
@@ -101,12 +101,12 @@
         </component>
     </settings>
     <settings pass="offlineServicing">
-        <component name="Microsoft-Windows-LUA-Settings" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <component name="Microsoft-Windows-LUA-Settings" processorArchitecture="${architecture}" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <EnableLUA>false</EnableLUA>
         </component>
     </settings>
     <settings pass="specialize">
-        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="${architecture}" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <OEMInformation>
                 <HelpCustomized>false</HelpCustomized>
             </OEMInformation>
@@ -114,22 +114,22 @@
             <TimeZone>UTC</TimeZone>
             <RegisteredOwner/>
         </component>
-        <component name="Microsoft-Windows-ServerManager-SvrMgrNc" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <component name="Microsoft-Windows-ServerManager-SvrMgrNc" processorArchitecture="${architecture}" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <DoNotOpenServerManagerAtLogon>true</DoNotOpenServerManagerAtLogon>
         </component>
-        <component name="Microsoft-Windows-IE-ESC" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <component name="Microsoft-Windows-IE-ESC" processorArchitecture="${architecture}" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <IEHardenAdmin>false</IEHardenAdmin>
             <IEHardenUser>false</IEHardenUser>
         </component>
-        <component name="Microsoft-Windows-OutOfBoxExperience" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <component name="Microsoft-Windows-OutOfBoxExperience" processorArchitecture="${architecture}" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <DoNotOpenInitialConfigurationTasksAtLogon>true</DoNotOpenInitialConfigurationTasksAtLogon>
         </component>
-        <component name="Microsoft-Windows-Security-SPP-UX" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <component name="Microsoft-Windows-Security-SPP-UX" processorArchitecture="${architecture}" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <SkipAutoActivation>true</SkipAutoActivation>
         </component>
     </settings>
     <settings pass="oobeSystem">
-        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="${architecture}" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <OOBE>
                 <HideEULAPage>true</HideEULAPage>
                 <HideLocalAccountScreen>true</HideLocalAccountScreen>
@@ -164,7 +164,7 @@
                 </SynchronousCommand>
             </FirstLogonCommands>
         </component>
-        <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <component name="Microsoft-Windows-International-Core" processorArchitecture="${architecture}" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <InputLocale>en-US</InputLocale>
             <SystemLocale>en-US</SystemLocale>
             <UILanguage>en-US</UILanguage>

--- a/src/windows/build.native.pkr.hcl
+++ b/src/windows/build.native.pkr.hcl
@@ -136,7 +136,7 @@ build {
   provisioner "powershell" {
     script       = "${path.root}/chef/apply.ps1"
     max_retries  = local.chef_max_retries
-    pause_before = "120s"
+    pause_before = "300s"
 
     env = local.native_chef_environment
 

--- a/src/windows/build.native.pkr.hcl
+++ b/src/windows/build.native.pkr.hcl
@@ -84,6 +84,12 @@ locals {
   native_vmware_options       = lookup(local.image_options, "vmware", {})
   native_vmware_tools_source  = lookup(local.native_vmware_options, "tools_source", "")
   native_vmware_tools_version = lookup(local.native_vmware_options, "tools_version", "")
+
+  native_chef_environment = {
+    CHEF_ATTRIBUTES      = local.chef_attributes
+    VMWARE_TOOLS_SOURCE  = local.native_vmware_tools_source
+    VMWARE_TOOLS_VERSION = local.native_vmware_tools_version
+  }
 }
 
 build {
@@ -113,11 +119,7 @@ build {
     script           = "${path.root}/chef/apply.ps1"
     valid_exit_codes = [0, 35]
 
-    env = {
-      CHEF_ATTRIBUTES      = local.chef_attributes
-      VMWARE_TOOLS_SOURCE  = local.native_vmware_tools_source
-      VMWARE_TOOLS_VERSION = local.native_vmware_tools_version
-    }
+    env = local.native_chef_environment
 
     elevated_user     = local.communicator.username
     elevated_password = local.communicator.password
@@ -136,11 +138,7 @@ build {
     max_retries  = local.chef_max_retries
     pause_before = "120s"
 
-    env = {
-      CHEF_ATTRIBUTES      = local.chef_attributes
-      VMWARE_TOOLS_SOURCE  = local.native_vmware_tools_source
-      VMWARE_TOOLS_VERSION = local.native_vmware_tools_version
-    }
+    env = local.native_chef_environment
 
     elevated_user     = local.communicator.username
     elevated_password = local.communicator.password

--- a/src/windows/build.native.pkr.hcl
+++ b/src/windows/build.native.pkr.hcl
@@ -86,13 +86,13 @@ locals {
   native_vmware_tools_version = lookup(local.native_vmware_options, "tools_version", "")
 
   native_virtualbox_options                   = lookup(local.image_options, "virtualbox", {})
-  native_virtualbox_guest_additions_reconcile = lookup(local.native_virtualbox_options, "guest_additions_reconcile", "false")
+  native_virtualbox_guest_additions_reconcile = local.image_provider == "virtualbox" ? lookup(local.native_virtualbox_options, "guest_additions_reconcile", "false") : "false"
 
   native_chef_environment = {
-    CHEF_ATTRIBUTES                       = local.chef_attributes
+    CHEF_ATTRIBUTES                      = local.chef_attributes
     VIRTUALBOX_GUEST_ADDITIONS_RECONCILE = local.native_virtualbox_guest_additions_reconcile
-    VMWARE_TOOLS_SOURCE                   = local.native_vmware_tools_source
-    VMWARE_TOOLS_VERSION                  = local.native_vmware_tools_version
+    VMWARE_TOOLS_SOURCE                  = local.native_vmware_tools_source
+    VMWARE_TOOLS_VERSION                 = local.native_vmware_tools_version
   }
 }
 

--- a/src/windows/build.native.pkr.hcl
+++ b/src/windows/build.native.pkr.hcl
@@ -26,6 +26,12 @@ locals {
   native_iso          = contains(keys(local.image_options.native), "source_iso_checksum")
   downloads_directory = "${coalesce(var.userprofile_directory, var.home_directory)}/Downloads"
 
+  native_unattended_options = {
+    architecture = local.image_architecture
+    boot         = local.image_options.native
+    provider     = lookup(local.image_options, local.image_provider, {})
+  }
+
   source_options_native = {
     iso_urls = local.native_iso ? [
       "${local.downloads_directory}/${local.image_options.native.source_iso_url_local}",
@@ -33,8 +39,8 @@ locals {
     ] : []
     iso_checksum = local.native_iso ? local.image_options.native.source_iso_checksum : ""
     cd_content = merge({
-      "autounattend.xml"             = templatefile("${path.root}/boot/autounattend.xml", { boot = local.image_options.native })
-      "autounattend-first-logon.ps1" = templatefile("${path.root}/boot/autounattend-first-logon.ps1", { boot = local.image_options.native })
+      "autounattend.xml"             = templatefile("${path.root}/boot/autounattend.xml", local.native_unattended_options)
+      "autounattend-first-logon.ps1" = templatefile("${path.root}/boot/autounattend-first-logon.ps1", local.native_unattended_options)
       }, {
       for setup_script in compact([lookup(local.image_options.native, "boot_setup_script", "")]) : setup_script => file("${path.cwd}/${setup_script}")
     })
@@ -60,6 +66,13 @@ build {
       "chef export ${local.artifacts_directory}/chef --force"
     ]
   }
+
+  provisioner "shell-local" {
+    inline = local.vmware_boot_drivers_enabled ? [
+      "mkdir -p \"${local.vmware_boot_drivers_directory}\"",
+      "unzip -jo \"${local.vmware_boot_drivers_archive}\" \"vmxnet3/Win10_1709/ARM64/vmxnet3.cat\" \"vmxnet3/Win10_1709/ARM64/vmxnet3.inf\" \"vmxnet3/Win10_1709/ARM64/vmxnet3.sys\" -d \"${local.vmware_boot_drivers_directory}\"",
+    ] : ["echo VMware boot drivers not required"]
+  }
 }
 
 locals {
@@ -67,6 +80,10 @@ locals {
   chef_max_retries = 10
   chef_attributes  = lookup(local.image_options.native, "chef_attributes", "")
   chef_keep        = lookup(local.image_options.native, "chef_keep", "false")
+
+  native_vmware_options       = lookup(local.image_options, "vmware", {})
+  native_vmware_tools_source  = lookup(local.native_vmware_options, "tools_source", "")
+  native_vmware_tools_version = lookup(local.native_vmware_options, "tools_version", "")
 }
 
 build {
@@ -97,7 +114,9 @@ build {
     valid_exit_codes = [0, 35]
 
     env = {
-      CHEF_ATTRIBUTES = local.chef_attributes
+      CHEF_ATTRIBUTES      = local.chef_attributes
+      VMWARE_TOOLS_SOURCE  = local.native_vmware_tools_source
+      VMWARE_TOOLS_VERSION = local.native_vmware_tools_version
     }
 
     elevated_user     = local.communicator.username
@@ -118,7 +137,9 @@ build {
     pause_before = "120s"
 
     env = {
-      CHEF_ATTRIBUTES = local.chef_attributes
+      CHEF_ATTRIBUTES      = local.chef_attributes
+      VMWARE_TOOLS_SOURCE  = local.native_vmware_tools_source
+      VMWARE_TOOLS_VERSION = local.native_vmware_tools_version
     }
 
     elevated_user     = local.communicator.username

--- a/src/windows/build.native.pkr.hcl
+++ b/src/windows/build.native.pkr.hcl
@@ -9,6 +9,11 @@ variable "home_directory" {
 }
 
 locals {
+  userprofile_directory_input = var.userprofile_directory
+  home_directory_input        = var.home_directory
+}
+
+locals {
   native_iso_sources = {
     virtualbox = "virtualbox-iso.core"
     vmware     = "vmware-iso.core"
@@ -24,7 +29,7 @@ locals {
   }
 
   native_iso          = contains(keys(local.image_options.native), "source_iso_checksum")
-  downloads_directory = "${coalesce(var.userprofile_directory, var.home_directory)}/Downloads"
+  downloads_directory = "${coalesce(local.userprofile_directory_input, local.home_directory_input)}/Downloads"
 
   native_unattended_options = {
     architecture = local.image_architecture
@@ -81,18 +86,16 @@ locals {
   chef_attributes  = lookup(local.image_options.native, "chef_attributes", "")
   chef_keep        = lookup(local.image_options.native, "chef_keep", "false")
 
-  native_vmware_options       = lookup(local.image_options, "vmware", {})
-  native_vmware_tools_source  = lookup(local.native_vmware_options, "tools_source", "")
-  native_vmware_tools_version = lookup(local.native_vmware_options, "tools_version", "")
-
-  native_virtualbox_options                   = lookup(local.image_options, "virtualbox", {})
-  native_virtualbox_guest_additions_reconcile = local.image_provider == "virtualbox" ? lookup(local.native_virtualbox_options, "guest_additions_reconcile", "false") : "false"
+  native_provider_options                   = lookup(local.image_options, local.image_provider, {})
+  native_provider_tools_source              = lookup(local.native_provider_options, "tools_source", "")
+  native_provider_tools_version             = lookup(local.native_provider_options, "tools_version", "")
+  native_provider_guest_additions_reconcile = lookup(local.native_provider_options, "guest_additions_reconcile", "false")
 
   native_chef_environment = {
     CHEF_ATTRIBUTES                      = local.chef_attributes
-    VIRTUALBOX_GUEST_ADDITIONS_RECONCILE = local.native_virtualbox_guest_additions_reconcile
-    VMWARE_TOOLS_SOURCE                  = local.native_vmware_tools_source
-    VMWARE_TOOLS_VERSION                 = local.native_vmware_tools_version
+    VIRTUALBOX_GUEST_ADDITIONS_RECONCILE = local.native_provider_guest_additions_reconcile
+    VMWARE_TOOLS_SOURCE                  = local.native_provider_tools_source
+    VMWARE_TOOLS_VERSION                 = local.native_provider_tools_version
   }
 }
 

--- a/src/windows/build.native.pkr.hcl
+++ b/src/windows/build.native.pkr.hcl
@@ -85,10 +85,14 @@ locals {
   native_vmware_tools_source  = lookup(local.native_vmware_options, "tools_source", "")
   native_vmware_tools_version = lookup(local.native_vmware_options, "tools_version", "")
 
+  native_virtualbox_options                   = lookup(local.image_options, "virtualbox", {})
+  native_virtualbox_guest_additions_reconcile = lookup(local.native_virtualbox_options, "guest_additions_reconcile", "false")
+
   native_chef_environment = {
-    CHEF_ATTRIBUTES      = local.chef_attributes
-    VMWARE_TOOLS_SOURCE  = local.native_vmware_tools_source
-    VMWARE_TOOLS_VERSION = local.native_vmware_tools_version
+    CHEF_ATTRIBUTES                       = local.chef_attributes
+    VIRTUALBOX_GUEST_ADDITIONS_RECONCILE = local.native_virtualbox_guest_additions_reconcile
+    VMWARE_TOOLS_SOURCE                   = local.native_vmware_tools_source
+    VMWARE_TOOLS_VERSION                  = local.native_vmware_tools_version
   }
 }
 

--- a/src/windows/build.vagrant.pkr.hcl
+++ b/src/windows/build.vagrant.pkr.hcl
@@ -67,14 +67,22 @@ locals {
 }
 
 source "file" "Vagrantfile" {
-  content = templatefile("${path.root}/vagrant/${local.image_provider}.Vagrantfile", { options = local.vagrant_options })
-  target  = "${local.artifacts_directory}/Vagrantfile"
+  content = templatefile("${path.root}/vagrant/${local.image_provider}.Vagrantfile", {
+    options          = local.vagrant_options
+    provider_options = lookup(local.image_options, local.image_provider, {})
+  })
+  target = "${local.artifacts_directory}/Vagrantfile"
+}
+
+source "file" "Autounattend" {
+  content = templatefile("${path.root}/vagrant/Autounattend.xml", { architecture = local.image_architecture })
+  target  = "${local.artifacts_directory}/Autounattend.xml"
 }
 
 build {
   name = "vagrant-restore"
 
-  sources = ["file.Vagrantfile"]
+  sources = ["file.Vagrantfile", "file.Autounattend"]
 }
 
 locals {
@@ -93,6 +101,11 @@ build {
   provisioner "file" {
     source      = "${path.root}/vagrant/"
     destination = local.packer_destination
+  }
+
+  provisioner "file" {
+    source      = "${local.artifacts_directory}/Autounattend.xml"
+    destination = "${local.packer_destination}/Autounattend.xml"
   }
 
   provisioner "powershell" {

--- a/src/windows/build.vagrant.pkr.hcl
+++ b/src/windows/build.vagrant.pkr.hcl
@@ -51,6 +51,7 @@ locals {
   vagrant_box_name       = lookup(local.vagrant_options, "box_name", replace(local.image_name, "/", "-"))
   vagrant_box_provider   = lookup(local.vagrant_providers, local.image_provider, "")
   vagrant_box_object_key = "${local.vagrant_box_name}/${local.image_version}/${local.vagrant_box_provider}/${local.image_architecture}/vagrant.box"
+  vagrant_test_box_name  = "${local.image_author}-test/${local.vagrant_box_name}"
 }
 
 locals {
@@ -140,12 +141,14 @@ build {
   provisioner "shell-local" {
     inline = [
       "vagrant destroy -f ${var.image}",
+      "vagrant box remove \"${local.vagrant_test_box_name}\" --all",
     ]
 
     valid_exit_codes = [0, 1]
 
     env = {
-      VAGRANT_BOX_URL = "${local.artifacts_directory}/vagrant/vagrant.box"
+      VAGRANT_BOX_AUTHOR = local.image_author
+      VAGRANT_BOX_URL    = "${local.artifacts_directory}/vagrant/vagrant.box"
     }
   }
 
@@ -157,19 +160,22 @@ build {
     max_retries = 1
 
     env = {
-      VAGRANT_BOX_URL = "${local.artifacts_directory}/vagrant/vagrant.box"
+      VAGRANT_BOX_AUTHOR = local.image_author
+      VAGRANT_BOX_URL    = "${local.artifacts_directory}/vagrant/vagrant.box"
     }
   }
 
   provisioner "shell-local" {
     inline = [
       "vagrant destroy -f ${var.image}",
+      "vagrant box remove \"${local.vagrant_test_box_name}\" --all",
     ]
 
     valid_exit_codes = [0, 1]
 
     env = {
-      VAGRANT_BOX_URL = "${local.artifacts_directory}/vagrant/vagrant.box"
+      VAGRANT_BOX_AUTHOR = local.image_author
+      VAGRANT_BOX_URL    = "${local.artifacts_directory}/vagrant/vagrant.box"
     }
   }
 }

--- a/src/windows/build.vagrant.pkr.hcl
+++ b/src/windows/build.vagrant.pkr.hcl
@@ -51,6 +51,7 @@ locals {
   vagrant_box_name       = lookup(local.vagrant_options, "box_name", replace(local.image_name, "/", "-"))
   vagrant_box_provider   = lookup(local.vagrant_providers, local.image_provider, "")
   vagrant_box_object_key = "${local.vagrant_box_name}/${local.image_version}/${local.vagrant_box_provider}/${local.image_architecture}/vagrant.box"
+  vagrant_box_tag        = "${local.image_author}/${local.vagrant_box_name}"
   vagrant_test_box_name  = "${local.image_author}-test/${local.vagrant_box_name}"
 }
 
@@ -140,7 +141,7 @@ build {
 
   provisioner "shell-local" {
     inline = [
-      "vagrant destroy -f ${var.image}",
+      "vagrant destroy -f ${local.image_key}",
       "vagrant box remove \"${local.vagrant_test_box_name}\" --all",
     ]
 
@@ -154,7 +155,7 @@ build {
 
   provisioner "shell-local" {
     inline = [
-      "vagrant up ${var.image} --provider ${lookup(local.vagrant_providers, local.image_provider, "")}",
+      "vagrant up ${local.image_key} --provider ${lookup(local.vagrant_providers, local.image_provider, "")}",
     ]
 
     max_retries = 1
@@ -167,7 +168,7 @@ build {
 
   provisioner "shell-local" {
     inline = [
-      "vagrant destroy -f ${var.image}",
+      "vagrant destroy -f ${local.image_key}",
       "vagrant box remove \"${local.vagrant_test_box_name}\" --all",
     ]
 
@@ -197,7 +198,7 @@ build {
     }
 
     post-processor "vagrant-registry" {
-      box_tag              = "${local.image_author}/${local.vagrant_box_name}"
+      box_tag              = local.vagrant_box_tag
       version              = local.image_version
       box_download_url     = "${local.box_artifact_origin}/${local.vagrant_box_object_key}"
       box_checksum         = "SHA256:${split("\t", file("${local.artifacts_directory}/checksum.sha256"))[0]}"
@@ -235,7 +236,8 @@ build {
 
   provisioner "shell-local" {
     inline = [
-      "vagrant destroy -f ${var.image}",
+      "vagrant destroy -f ${local.image_key}",
+      "vagrant box remove \"${local.vagrant_box_tag}\" --all",
     ]
 
     valid_exit_codes = [0, 1]
@@ -243,7 +245,7 @@ build {
 
   provisioner "shell-local" {
     inline = [
-      "vagrant up ${var.image} --provider ${lookup(local.vagrant_providers, local.image_provider, "")}",
+      "vagrant up ${local.image_key} --provider ${lookup(local.vagrant_providers, local.image_provider, "")}",
     ]
 
     max_retries = 1
@@ -251,7 +253,8 @@ build {
 
   provisioner "shell-local" {
     inline = [
-      "vagrant destroy -f ${var.image}",
+      "vagrant destroy -f ${local.image_key}",
+      "vagrant box remove \"${local.vagrant_box_tag}\" --all",
     ]
 
     valid_exit_codes = [0, 1]

--- a/src/windows/build.vagrant.pkr.hcl
+++ b/src/windows/build.vagrant.pkr.hcl
@@ -50,18 +50,20 @@ locals {
 
   vagrant_box_name       = lookup(local.vagrant_options, "box_name", replace(local.image_name, "/", "-"))
   vagrant_box_provider   = lookup(local.vagrant_providers, local.image_provider, "")
-  vagrant_box_object_key = "${local.vagrant_box_name}/${local.image_version}/${local.vagrant_box_provider}/${local.vagrant_options.architecture}/vagrant.box"
+  vagrant_box_object_key = "${local.vagrant_box_name}/${local.image_version}/${local.vagrant_box_provider}/${local.image_architecture}/vagrant.box"
 }
 
 locals {
   vagrant_options_core = {
-    cpus         = "2"
-    memory       = "2048"
-    ports        = "3389"
-    architecture = "amd64"
+    cpus   = "2"
+    memory = "2048"
+    ports  = "3389"
   }
   vagrant_options_image = lookup(local.image_options, "vagrant", {})
   vagrant_options       = merge(local.vagrant_options_core, local.vagrant_options_image)
+
+  vagrant_default_architecture       = lookup(local.vagrant_options, "default_architecture", "amd64")
+  vagrant_alias_default_architecture = lookup(local.vagrant_options, "alias_default_architecture", local.vagrant_default_architecture)
 }
 
 source "file" "Vagrantfile" {
@@ -180,8 +182,8 @@ build {
       version              = local.image_version
       box_download_url     = "${local.box_artifact_origin}/${local.vagrant_box_object_key}"
       box_checksum         = "SHA256:${split("\t", file("${local.artifacts_directory}/checksum.sha256"))[0]}"
-      architecture         = local.vagrant_options.architecture
-      default_architecture = local.vagrant_options.architecture
+      architecture         = local.image_architecture
+      default_architecture = local.vagrant_default_architecture
       // no_release           = true
     }
   }
@@ -197,10 +199,10 @@ build {
       post-processor "vagrant-registry" {
         box_tag              = "${local.image_author}/${post-processors.value}"
         version              = local.image_version
-        box_download_url     = "https://vagrantcloud.com/${local.image_author}/boxes/${lookup(local.vagrant_options, "box_name", replace(local.image_name, "/", "-"))}/versions/${local.image_version}/providers/${lookup(local.vagrant_providers, local.image_provider, "")}/${local.vagrant_options.architecture}/vagrant.box"
+        box_download_url     = "https://vagrantcloud.com/${local.image_author}/boxes/${lookup(local.vagrant_options, "box_name", replace(local.image_name, "/", "-"))}/versions/${local.image_version}/providers/${lookup(local.vagrant_providers, local.image_provider, "")}/${local.image_architecture}/vagrant.box"
         box_checksum         = "SHA256:${split("\t", file("${local.artifacts_directory}/checksum.sha256"))[0]}"
-        architecture         = local.vagrant_options.architecture
-        default_architecture = local.vagrant_options.architecture
+        architecture         = local.image_architecture
+        default_architecture = local.vagrant_alias_default_architecture
         // no_release           = true
       }
     }

--- a/src/windows/chef/apply.ps1
+++ b/src/windows/chef/apply.ps1
@@ -3,7 +3,8 @@ $ProgressPreference = 'SilentlyContinue'
 
 cd C:/Windows/Temp/chef
 
-$runOptions = "--local-mode"
+# Chef 18.10.17 races while exporting Windows certificate keys during parallel cookbook sync.
+$runOptions = "--local-mode --config-option cookbook_sync_threads=1"
 
 if (![string]::IsNullOrEmpty($env:CHEF_ATTRIBUTES)) {
   $runOptions = "$($runOptions) --json-attributes attributes.$($env:CHEF_ATTRIBUTES).json"

--- a/src/windows/chef/cookbooks/gusztavvargadr_packer_windows/recipes/apply.rb
+++ b/src/windows/chef/cookbooks/gusztavvargadr_packer_windows/recipes/apply.rb
@@ -9,5 +9,5 @@ end
 reboot 'gusztavvargadr_packer_windows::apply' do
   delay_mins 1
   action :reboot_now
-  only_if { reboot_pending? }
+  only_if { node.run_state['gusztavvargadr_windows_updates_installed'] || reboot_pending? }
 end

--- a/src/windows/chef/cookbooks/gusztavvargadr_packer_windows/recipes/initialize.rb
+++ b/src/windows/chef/cookbooks/gusztavvargadr_packer_windows/recipes/initialize.rb
@@ -121,14 +121,16 @@ if vmware?
   configured_vmware_tools_version = ENV.fetch('VMWARE_TOOLS_VERSION', '')
   configured_vmware_tools_source = ENV.fetch('VMWARE_TOOLS_SOURCE', '')
 
-  vmware_tools_version_matches = if configured_vmware_tools_version.empty?
-    vmware_version.include?('13.')
-  else
-    vmware_version[/\A\d+\.\d+\.\d+/] == configured_vmware_tools_version
+  vmware_tools_version_matches = vmware_version.include?('13.')
+  unless configured_vmware_tools_version.empty?
+    vmware_tools_version_matches = vmware_version[/\A\d+\.\d+\.\d+/] == configured_vmware_tools_version
   end
 
   unless vmware_tools_version_matches
-    vmware_tools_source = configured_vmware_tools_source.empty? ? 'https://packages-prod.broadcom.com/tools/releases/13.1.0/windows/x64/VMware-tools-13.1.0-25218885-x64.exe' : configured_vmware_tools_source
+    vmware_tools_source = configured_vmware_tools_source
+    if vmware_tools_source.empty?
+      vmware_tools_source = 'https://packages-prod.broadcom.com/tools/releases/13.1.0/windows/x64/VMware-tools-13.1.0-25218885-x64.exe'
+    end
     vmware_tools_target = "#{Chef::Config['file_cache_path']}/VMware-tools.exe"
 
     remote_file vmware_tools_target do

--- a/src/windows/chef/cookbooks/gusztavvargadr_packer_windows/recipes/initialize.rb
+++ b/src/windows/chef/cookbooks/gusztavvargadr_packer_windows/recipes/initialize.rb
@@ -118,9 +118,17 @@ end
 
 if vmware?
   vmware_version = (powershell_out('& "C:/Program Files/VMware/VMware Tools/VMwareToolboxCmd.exe" -v').stdout rescue '').strip
+  configured_vmware_tools_version = ENV.fetch('VMWARE_TOOLS_VERSION', '')
+  configured_vmware_tools_source = ENV.fetch('VMWARE_TOOLS_SOURCE', '')
 
-  unless vmware_version.include?('13.')
-    vmware_tools_source = 'https://packages-prod.broadcom.com/tools/releases/13.1.0/windows/x64/VMware-tools-13.1.0-25218885-x64.exe'
+  vmware_tools_version_matches = if configured_vmware_tools_version.empty?
+    vmware_version.include?('13.')
+  else
+    vmware_version[/\A\d+\.\d+\.\d+/] == configured_vmware_tools_version
+  end
+
+  unless vmware_tools_version_matches
+    vmware_tools_source = configured_vmware_tools_source.empty? ? 'https://packages-prod.broadcom.com/tools/releases/13.1.0/windows/x64/VMware-tools-13.1.0-25218885-x64.exe' : configured_vmware_tools_source
     vmware_tools_target = "#{Chef::Config['file_cache_path']}/VMware-tools.exe"
 
     remote_file vmware_tools_target do

--- a/src/windows/chef/cookbooks/gusztavvargadr_packer_windows/recipes/initialize.rb
+++ b/src/windows/chef/cookbooks/gusztavvargadr_packer_windows/recipes/initialize.rb
@@ -72,13 +72,15 @@ remote_file sdelete_executable_target do
   action :create
 end
 
-if vbox?
-  vbox_version = (powershell_out('& "C:/Program Files/Oracle/VirtualBox Guest Additions/VBoxGuest/VBoxControl.exe" -v').stdout rescue '').strip
+configured_vbox_guest_additions_reconcile = ENV.fetch('VIRTUALBOX_GUEST_ADDITIONS_RECONCILE', 'false') == 'true'
 
-  unless vbox_version.include?('7.')
-    vbox_version = powershell_out('cat $env:HOME/.vbox_version').stdout.strip
+if vbox? || configured_vbox_guest_additions_reconcile
+  host_vbox_version = powershell_out('(Get-Content "$env:HOME/.vbox_version").Trim()').stdout.strip
+  guest_vbox_version = (powershell_out('& "C:/Program Files/Oracle/VirtualBox Guest Additions/VBoxGuest/VBoxControl.exe" -v').stdout rescue '').strip.sub(/r.*\z/, '')
+
+  unless guest_vbox_version == host_vbox_version
     vbox_guest_additions_path = "#{Chef::Config['file_cache_path']}/VBoxGuestAdditions.iso"
-    vbox_guest_additions_source = "https://download.virtualbox.org/virtualbox/#{vbox_version}/VBoxGuestAdditions_#{vbox_version}.iso"
+    vbox_guest_additions_source = "https://download.virtualbox.org/virtualbox/#{host_vbox_version}/VBoxGuestAdditions_#{host_vbox_version}.iso"
 
     remote_file vbox_guest_additions_path do
       source vbox_guest_additions_source

--- a/src/windows/chef/cookbooks/gusztavvargadr_packer_windows/recipes/initialize.rb
+++ b/src/windows/chef/cookbooks/gusztavvargadr_packer_windows/recipes/initialize.rb
@@ -117,7 +117,8 @@ if vbox?
 end
 
 if vmware?
-  vmware_version = (powershell_out('& "C:/Program Files/VMware/VMware Tools/VMwareToolboxCmd.exe" -v').stdout rescue '').strip
+  vmware_tools_path = 'C:/Program Files/VMware/VMware Tools/vmtoolsd.exe'
+  vmware_version = (powershell_out("(Get-Item '#{vmware_tools_path}').VersionInfo.FileVersion").stdout rescue '').strip
   configured_vmware_tools_version = ENV.fetch('VMWARE_TOOLS_VERSION', '')
   configured_vmware_tools_source = ENV.fetch('VMWARE_TOOLS_SOURCE', '')
 

--- a/src/windows/chef/cookbooks/gusztavvargadr_packer_windows/recipes/initialize.rb
+++ b/src/windows/chef/cookbooks/gusztavvargadr_packer_windows/recipes/initialize.rb
@@ -75,10 +75,17 @@ end
 configured_vbox_guest_additions_reconcile = ENV.fetch('VIRTUALBOX_GUEST_ADDITIONS_RECONCILE', 'false') == 'true'
 
 if vbox? || configured_vbox_guest_additions_reconcile
-  host_vbox_version = powershell_out('(Get-Content "$env:HOME/.vbox_version").Trim()').stdout.strip
-  guest_vbox_version = (powershell_out('& "C:/Program Files/Oracle/VirtualBox Guest Additions/VBoxGuest/VBoxControl.exe" -v').stdout rescue '').strip.sub(/r.*\z/, '')
+  installed_vbox_version = (powershell_out('& "C:/Program Files/Oracle/VirtualBox Guest Additions/VBoxGuest/VBoxControl.exe" -v').stdout rescue '').strip
+  host_vbox_version = nil
+  vbox_guest_additions_current = installed_vbox_version.include?('7.')
 
-  unless guest_vbox_version == host_vbox_version
+  if configured_vbox_guest_additions_reconcile
+    host_vbox_version = powershell_out('(Get-Content "$env:HOME/.vbox_version").Trim()').stdout.strip
+    vbox_guest_additions_current = installed_vbox_version.sub(/r.*\z/, '') == host_vbox_version
+  end
+
+  unless vbox_guest_additions_current
+    host_vbox_version ||= powershell_out('(Get-Content "$env:HOME/.vbox_version").Trim()').stdout.strip
     vbox_guest_additions_path = "#{Chef::Config['file_cache_path']}/VBoxGuestAdditions.iso"
     vbox_guest_additions_source = "https://download.virtualbox.org/virtualbox/#{host_vbox_version}/VBoxGuestAdditions_#{host_vbox_version}.iso"
 

--- a/src/windows/core.pkr.hcl
+++ b/src/windows/core.pkr.hcl
@@ -29,12 +29,13 @@ variable "build" {
 locals {
   image_options = var.images[var.image]
 
-  image_author      = var.author
-  image_name        = "${basename(path.cwd)}/${var.image}"
-  image_description = local.image_options.core.image_description
-  image_version     = var.version
-  image_provider    = var.provider
-  image_build       = var.build
+  image_author       = var.author
+  image_name         = "${basename(path.cwd)}/${var.image}"
+  image_description  = local.image_options.core.image_description
+  image_architecture = lookup(local.image_options.core, "architecture", "amd64")
+  image_version      = var.version
+  image_provider     = var.provider
+  image_build        = var.build
 
   artifacts_directory = "${path.cwd}/../../artifacts/${local.image_name}/${local.image_provider}/${var.build}"
 }

--- a/src/windows/core.pkr.hcl
+++ b/src/windows/core.pkr.hcl
@@ -27,15 +27,25 @@ variable "build" {
 }
 
 locals {
-  image_options = var.images[var.image]
+  image_catalog_input  = var.images
+  image_key_input      = var.image
+  image_author_input   = var.author
+  image_version_input  = var.version
+  image_provider_input = var.provider
+  image_build_input    = var.build
+}
 
-  image_author       = var.author
-  image_name         = "${basename(path.cwd)}/${var.image}"
+locals {
+  image_options = local.image_catalog_input[local.image_key_input]
+
+  image_key          = local.image_key_input
+  image_author       = local.image_author_input
+  image_name         = "${basename(path.cwd)}/${local.image_key}"
   image_description  = local.image_options.core.image_description
   image_architecture = lookup(local.image_options.core, "architecture", "amd64")
-  image_version      = var.version
-  image_provider     = var.provider
-  image_build        = var.build
+  image_version      = local.image_version_input
+  image_provider     = local.image_provider_input
+  image_build        = local.image_build_input
 
-  artifacts_directory = "${path.cwd}/../../artifacts/${local.image_name}/${local.image_provider}/${var.build}"
+  artifacts_directory = "${path.cwd}/../../artifacts/${local.image_name}/${local.image_provider}/${local.image_build}"
 }

--- a/src/windows/core.pkr.hcl
+++ b/src/windows/core.pkr.hcl
@@ -32,7 +32,7 @@ locals {
   image_author      = var.author
   image_name        = "${basename(path.cwd)}/${var.image}"
   image_description = local.image_options.core.image_description
-  image_version     = contains(keys(local.image_options.core), "image_version") ? "${local.image_options.core.image_version}.${var.version}" : "${var.version}.0.0"
+  image_version     = var.version
   image_provider    = var.provider
   image_build       = var.build
 

--- a/src/windows/source.hyperv.pkr.hcl
+++ b/src/windows/source.hyperv.pkr.hcl
@@ -13,6 +13,10 @@ variable "hyperv_switch" {
 }
 
 locals {
+  hyperv_switch_input = var.hyperv_switch
+}
+
+locals {
   hyperv_source_options = {
     generation                       = 2
     configuration_version            = "10.0"
@@ -20,7 +24,7 @@ locals {
     enable_dynamic_memory            = false
     enable_secure_boot               = true
     secure_boot_template             = "MicrosoftWindows"
-    switch_name                      = var.hyperv_switch
+    switch_name                      = local.hyperv_switch_input
     enable_mac_spoofing              = true
 
     boot_wait = "-1s"

--- a/src/windows/source.virtualbox.pkr.hcl
+++ b/src/windows/source.virtualbox.pkr.hcl
@@ -28,8 +28,15 @@ locals {
 }
 
 locals {
-  virtualbox_iso_source_options = merge(local.source_options_build, local.virtualbox_source_options, lookup(local.image_options, "virtualbox", {}))
-  virtualbox_iso_arm64          = local.image_architecture == "arm64"
+  virtualbox_image_options = lookup(local.image_options, "virtualbox", {})
+
+  virtualbox_boot_command_key_buffer = lookup(local.virtualbox_image_options, "boot_command_key_buffer", "false") == "true" ? join("", [for index in range(32) : " "]) : ""
+  virtualbox_remove_ide_controller   = lookup(local.virtualbox_image_options, "remove_ide_controller", "false") == "true"
+
+  virtualbox_iso_source_options = merge(local.source_options_build, local.virtualbox_source_options, local.virtualbox_image_options)
+  virtualbox_iso_boot_command = [
+    for index, command in local.virtualbox_iso_source_options.boot_command : index == 0 ? command : "${local.virtualbox_boot_command_key_buffer}${command}"
+  ]
 }
 
 source "virtualbox-iso" "core" {
@@ -61,14 +68,14 @@ source "virtualbox-iso" "core" {
   usb                  = local.virtualbox_iso_source_options.usb
   usb_controller       = local.virtualbox_iso_source_options.usb_controller
 
-  # The plugin creates an unused IDE controller which VirtualBox cannot assign on ARM64.
-  vboxmanage = local.virtualbox_iso_arm64 ? [
+  # Remove the plugin-created IDE controller when the selected image cannot assign it.
+  vboxmanage = local.virtualbox_remove_ide_controller ? [
     ["storagectl", "{{.Name}}", "--name", "IDE", "--remove"]
   ] : []
 
-  boot_command           = local.virtualbox_iso_source_options.boot_command
-  boot_keygroup_interval = local.virtualbox_iso_arm64 ? "1s" : "100ms"
-  boot_wait              = local.virtualbox_iso_arm64 ? "10s" : local.virtualbox_iso_source_options.boot_wait
+  boot_command           = local.virtualbox_iso_boot_command
+  boot_keygroup_interval = lookup(local.virtualbox_image_options, "boot_keygroup_interval", "100ms")
+  boot_wait              = local.virtualbox_iso_source_options.boot_wait
   shutdown_command       = local.virtualbox_iso_source_options.shutdown_command
   shutdown_timeout       = local.virtualbox_iso_source_options.shutdown_timeout
 
@@ -79,7 +86,7 @@ source "virtualbox-iso" "core" {
 }
 
 locals {
-  virtualbox_ovf_source_options = merge(local.source_options_build, local.virtualbox_source_options, lookup(local.image_options, "virtualbox", {}))
+  virtualbox_ovf_source_options = merge(local.source_options_build, local.virtualbox_source_options, local.virtualbox_image_options)
 }
 
 source "virtualbox-ovf" "core" {

--- a/src/windows/source.virtualbox.pkr.hcl
+++ b/src/windows/source.virtualbox.pkr.hcl
@@ -1,7 +1,7 @@
 packer {
   required_plugins {
     virtualbox = {
-      version = "~> 1.1"
+      version = "~> 1.1.4"
       source  = "github.com/hashicorp/virtualbox"
     }
   }
@@ -9,18 +9,27 @@ packer {
 
 locals {
   virtualbox_source_options = {
+    audio_controller     = "ac97"
+    chipset              = "piix3"
     guest_additions_mode = "disable"
     firmware             = "efi"
     nested_virt          = false
     hard_drive_interface = "sata"
+    iso_interface        = "ide"
     gfx_controller       = "vboxsvga"
     gfx_vram_size        = 64
+    keyboard             = "ps2"
+    mouse                = "ps2"
+    nic_type             = "82540EM"
     post_shutdown_delay  = "15s"
+    usb                  = false
+    usb_controller       = "ehci"
   }
 }
 
 locals {
   virtualbox_iso_source_options = merge(local.source_options_build, local.virtualbox_source_options, lookup(local.image_options, "virtualbox", {}))
+  virtualbox_iso_arm64          = local.image_architecture == "arm64"
 }
 
 source "virtualbox-iso" "core" {
@@ -35,19 +44,33 @@ source "virtualbox-iso" "core" {
   iso_checksum = local.virtualbox_iso_source_options.iso_checksum
   cd_content   = local.virtualbox_iso_source_options.cd_content
 
-  guest_os_type        = local.virtualbox_iso_source_options.guest_os_type
+  audio_controller     = local.virtualbox_iso_source_options.audio_controller
+  chipset              = local.virtualbox_iso_source_options.chipset
   guest_additions_mode = local.virtualbox_iso_source_options.guest_additions_mode
   firmware             = local.virtualbox_iso_source_options.firmware
-  nested_virt          = local.virtualbox_iso_source_options.nested_virt
-  hard_drive_interface = local.virtualbox_iso_source_options.hard_drive_interface
   gfx_controller       = local.virtualbox_iso_source_options.gfx_controller
   gfx_vram_size        = local.virtualbox_iso_source_options.gfx_vram_size
+  guest_os_type        = local.virtualbox_iso_source_options.guest_os_type
+  hard_drive_interface = local.virtualbox_iso_source_options.hard_drive_interface
+  iso_interface        = local.virtualbox_iso_source_options.iso_interface
+  keyboard             = local.virtualbox_iso_source_options.keyboard
+  mouse                = local.virtualbox_iso_source_options.mouse
+  nested_virt          = local.virtualbox_iso_source_options.nested_virt
+  nic_type             = local.virtualbox_iso_source_options.nic_type
   post_shutdown_delay  = local.virtualbox_iso_source_options.post_shutdown_delay
+  usb                  = local.virtualbox_iso_source_options.usb
+  usb_controller       = local.virtualbox_iso_source_options.usb_controller
 
-  boot_command     = local.virtualbox_iso_source_options.boot_command
-  boot_wait        = local.virtualbox_iso_source_options.boot_wait
-  shutdown_command = local.virtualbox_iso_source_options.shutdown_command
-  shutdown_timeout = local.virtualbox_iso_source_options.shutdown_timeout
+  # The plugin creates an unused IDE controller which VirtualBox cannot assign on ARM64.
+  vboxmanage = local.virtualbox_iso_arm64 ? [
+    ["storagectl", "{{.Name}}", "--name", "IDE", "--remove"]
+  ] : []
+
+  boot_command           = local.virtualbox_iso_source_options.boot_command
+  boot_keygroup_interval = local.virtualbox_iso_arm64 ? "1s" : "100ms"
+  boot_wait              = local.virtualbox_iso_arm64 ? "10s" : local.virtualbox_iso_source_options.boot_wait
+  shutdown_command       = local.virtualbox_iso_source_options.shutdown_command
+  shutdown_timeout       = local.virtualbox_iso_source_options.shutdown_timeout
 
   communicator = local.communicator.type
   ssh_username = local.communicator.username

--- a/src/windows/source.vmware.pkr.hcl
+++ b/src/windows/source.vmware.pkr.hcl
@@ -21,7 +21,6 @@ locals {
     vmx_data = merge(
       {
         firmware        = "efi"
-        "vhv.enable"    = "FALSE"
         "sata1.present" = "TRUE"
       },
       local.image_architecture == "arm64" ? {

--- a/src/windows/source.vmware.pkr.hcl
+++ b/src/windows/source.vmware.pkr.hcl
@@ -28,10 +28,11 @@ locals {
 }
 
 locals {
-  vmware_image_options = lookup(local.image_options, "vmware", {})
+  vmware_fusion_application_path = var.vmware_fusion_application_path
+  vmware_image_options           = lookup(local.image_options, "vmware", {})
 
   vmware_boot_drivers_enabled   = local.native_build && local.image_provider == "vmware" && lookup(local.vmware_image_options, "boot_driver_archive", "") != ""
-  vmware_boot_drivers_archive   = "${var.vmware_fusion_application_path}/${lookup(local.vmware_image_options, "boot_driver_archive", "")}"
+  vmware_boot_drivers_archive   = "${local.vmware_fusion_application_path}/${lookup(local.vmware_image_options, "boot_driver_archive", "")}"
   vmware_boot_drivers_directory = "${local.artifacts_directory}/boot-drivers"
   vmware_boot_driver_files      = local.vmware_boot_drivers_enabled ? ["${local.vmware_boot_drivers_directory}/*"] : []
 

--- a/src/windows/source.vmware.pkr.hcl
+++ b/src/windows/source.vmware.pkr.hcl
@@ -7,6 +7,12 @@ packer {
   }
 }
 
+variable "vmware_fusion_application_path" {
+  type        = string
+  description = "The VMware Fusion application used as the source of Windows ARM64 boot drivers."
+  default     = "/Applications/VMware Fusion.app"
+}
+
 locals {
   vmware_source_options = {
     version           = 20
@@ -22,7 +28,14 @@ locals {
 }
 
 locals {
-  vmware_iso_source_options = merge(local.source_options_build, local.vmware_source_options, lookup(local.image_options, "vmware", {}))
+  vmware_image_options = lookup(local.image_options, "vmware", {})
+
+  vmware_boot_drivers_enabled   = local.native_build && local.image_provider == "vmware" && lookup(local.vmware_image_options, "boot_driver_archive", "") != ""
+  vmware_boot_drivers_archive   = "${var.vmware_fusion_application_path}/${lookup(local.vmware_image_options, "boot_driver_archive", "")}"
+  vmware_boot_drivers_directory = "${local.artifacts_directory}/boot-drivers"
+  vmware_boot_driver_files      = local.vmware_boot_drivers_enabled ? ["${local.vmware_boot_drivers_directory}/*"] : []
+
+  vmware_iso_source_options = merge(local.source_options_build, local.vmware_source_options, local.vmware_image_options)
 }
 
 source "vmware-iso" "core" {
@@ -36,11 +49,13 @@ source "vmware-iso" "core" {
   iso_urls     = local.vmware_iso_source_options.iso_urls
   iso_checksum = local.vmware_iso_source_options.iso_checksum
   cd_content   = local.vmware_iso_source_options.cd_content
+  cd_files     = local.vmware_boot_driver_files
 
   version                        = local.vmware_iso_source_options.version
   guest_os_type                  = local.vmware_iso_source_options.guest_os_type
   disk_type_id                   = local.vmware_iso_source_options.disk_type_id
   disk_adapter_type              = local.vmware_iso_source_options.disk_adapter_type
+  network_adapter_type           = try(local.vmware_iso_source_options.network_adapter_type, null)
   vmx_data                       = local.vmware_iso_source_options.vmx_data
   vmx_remove_ethernet_interfaces = local.vmware_iso_source_options.vmx_remove_ethernet_interfaces
 
@@ -49,14 +64,14 @@ source "vmware-iso" "core" {
   shutdown_command = local.vmware_iso_source_options.shutdown_command
   shutdown_timeout = local.vmware_iso_source_options.shutdown_timeout
 
-  communicator   = local.communicator.type
-  ssh_username   = local.communicator.username
-  ssh_password   = local.communicator.password
-  ssh_timeout    = local.communicator.timeout
+  communicator = local.communicator.type
+  ssh_username = local.communicator.username
+  ssh_password = local.communicator.password
+  ssh_timeout  = local.communicator.timeout
 }
 
 locals {
-  vmware_vmx_source_options = merge(local.source_options_build, local.vmware_source_options, lookup(local.image_options, "vmware", {}))
+  vmware_vmx_source_options = merge(local.source_options_build, local.vmware_source_options, local.vmware_image_options)
 }
 
 source "vmware-vmx" "core" {
@@ -73,8 +88,8 @@ source "vmware-vmx" "core" {
   shutdown_command = local.vmware_vmx_source_options.shutdown_command
   shutdown_timeout = local.vmware_vmx_source_options.shutdown_timeout
 
-  communicator   = local.communicator.type
-  ssh_username   = local.communicator.username
-  ssh_password   = local.communicator.password
-  ssh_timeout    = local.communicator.timeout
+  communicator = local.communicator.type
+  ssh_username = local.communicator.username
+  ssh_password = local.communicator.password
+  ssh_timeout  = local.communicator.timeout
 }

--- a/src/windows/source.vmware.pkr.hcl
+++ b/src/windows/source.vmware.pkr.hcl
@@ -18,11 +18,17 @@ locals {
     version           = 20
     disk_type_id      = 0
     disk_adapter_type = "nvme"
-    vmx_data = {
-      firmware        = "efi"
-      "vhv.enable"    = "FALSE"
-      "sata1.present" = "TRUE"
-    }
+    vmx_data = merge(
+      {
+        firmware        = "efi"
+        "vhv.enable"    = "FALSE"
+        "sata1.present" = "TRUE"
+      },
+      local.image_architecture == "arm64" ? {
+        # VMware ARM64 requires xHCI for Packer's VNC boot keystrokes to reach EFI.
+        "usb_xhci.present" = true
+      } : {},
+    )
     vmx_remove_ethernet_interfaces = local.native_build ? false : true
   }
 }

--- a/src/windows/source.vmware.pkr.hcl
+++ b/src/windows/source.vmware.pkr.hcl
@@ -18,16 +18,10 @@ locals {
     version           = 20
     disk_type_id      = 0
     disk_adapter_type = "nvme"
-    vmx_data = merge(
-      {
-        firmware        = "efi"
-        "sata1.present" = "TRUE"
-      },
-      local.image_architecture == "arm64" ? {
-        # VMware ARM64 requires xHCI for Packer's VNC boot keystrokes to reach EFI.
-        "usb_xhci.present" = true
-      } : {},
-    )
+    vmx_data = {
+      firmware        = "efi"
+      "sata1.present" = "TRUE"
+    }
     vmx_remove_ethernet_interfaces = local.native_build ? false : true
   }
 }
@@ -35,13 +29,20 @@ locals {
 locals {
   vmware_fusion_application_path = var.vmware_fusion_application_path
   vmware_image_options           = lookup(local.image_options, "vmware", {})
+  vmware_image_vmx_data = {
+    for key, value in {
+      "usb_xhci.present" = lookup(local.vmware_image_options, "vmx_usb_xhci_present", "")
+    } : key => value if value != ""
+  }
 
   vmware_boot_drivers_enabled   = local.native_build && local.image_provider == "vmware" && lookup(local.vmware_image_options, "boot_driver_archive", "") != ""
   vmware_boot_drivers_archive   = "${local.vmware_fusion_application_path}/${lookup(local.vmware_image_options, "boot_driver_archive", "")}"
   vmware_boot_drivers_directory = "${local.artifacts_directory}/boot-drivers"
   vmware_boot_driver_files      = local.vmware_boot_drivers_enabled ? ["${local.vmware_boot_drivers_directory}/*"] : []
 
-  vmware_iso_source_options = merge(local.source_options_build, local.vmware_source_options, local.vmware_image_options)
+  vmware_iso_source_options = merge(local.source_options_build, local.vmware_source_options, local.vmware_image_options, {
+    vmx_data = merge(local.vmware_source_options.vmx_data, local.vmware_image_vmx_data)
+  })
 }
 
 source "vmware-iso" "core" {

--- a/src/windows/vagrant/Autounattend.xml
+++ b/src/windows/vagrant/Autounattend.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <unattend xmlns="urn:schemas-microsoft-com:unattend">
     <settings pass="oobeSystem">
-      <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <component name="Microsoft-Windows-International-Core" processorArchitecture="${architecture}" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
           <InputLocale>en-US</InputLocale>
           <SystemLocale>en-US</SystemLocale>
           <UILanguage>en-US</UILanguage>
           <UserLocale>en-US</UserLocale>
       </component>
-      <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="${architecture}" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <OOBE>
                 <HideEULAPage>true</HideEULAPage>
                 <HideLocalAccountScreen>true</HideLocalAccountScreen>

--- a/src/windows/vagrant/cleanup.ps1
+++ b/src/windows/vagrant/cleanup.ps1
@@ -1,3 +1,3 @@
 Get-AppxPackage -Name "*BingSearch*" | Remove-AppxPackage
 Get-AppxPackage -Name "*GameAssist*" | Remove-AppxPackage
-Get-AppxPackage -Name "*MicrosoftEdge*" | Remove-AppxPackage
+Get-AppxPackage -Name "*MicrosoftEdge*" | Where-Object { $_.Name -ne 'Microsoft.MicrosoftEdgeDevToolsClient' } | Remove-AppxPackage

--- a/src/windows/vagrant/vmware.Vagrantfile
+++ b/src/windows/vagrant/vmware.Vagrantfile
@@ -10,5 +10,9 @@ Vagrant.configure(2) do |config|
 %{ for port in compact(split(",", options.ports)) ~}
     override.vm.network :forwarded_port, guest: ${port}, host: ${50000 + port}, auto_correct: true
 %{ endfor ~}
+%{ for network_adapter_type in compact([lookup(provider_options, "network_adapter_type", "")]) ~}
+    provider.vmx["ethernet0.pcislotnumber"] = "${lookup(provider_options, "network_adapter_pcislotnumber", "160")}"
+    provider.vmx["ethernet0.virtualDev"] = "${network_adapter_type}"
+%{ endfor ~}
   end
 end


### PR DESCRIPTION
## Summary

Adds native ARM64 Ubuntu and Windows images for Apple-silicon macOS while preserving existing AMD64 contracts and provider identities. VirtualBox Guest Additions are skipped on unsupported Ubuntu ARM64 guests; VMware continues to use its supported guest tools.

### Relationships

- Related to #533
  - Resolves #534
  - Resolves #535
  - Resolves #536
  - Resolves #537
  - Resolves #538
  - Resolves #539
  - Resolves #540
  - Resolves #541
