### PR TITLE
Configure Windows Images for High Performance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,26 @@ Run `packer fmt` for HCL. Use Packer input variables only to capture external in
 
 There is no standalone unit-test suite or typechecking step. When a generic skill asks for typechecking, individual test files, or a full test suite, follow these repository-specific checks instead. For build changes, validation is performed by Packer’s `test` build stage for a complete configuration tuple; test the smallest affected sample/provider combination locally and rely on the corresponding Azure Pipeline matrix for provider coverage. For documentation-only changes, run the relevant format or syntax checks for the changed artifacts. Never commit `packer_cache`, `.vagrant`, or `artifacts`.
 
+## Build and log context hygiene
+
+Packer, Cake, Vagrant, Docker, and virtualization builds are transcript-heavy. After implementation, delegate each independent configuration tuple or log-analysis pass to one non-editing build worker when possible.
+
+Save complete build output to a unique temporary or ignored log file. Report only the configuration tuple, command, duration, exit status, first failing stage, a bounded relevant excerpt, and the log path. Do not paste complete logs into the main task.
+
+Run quick formatting and syntax checks directly in the main task. Keep complete image builds, repeated polling, and broad failure-log analysis outside the main task unless they are inseparable from the current edit.
+
+## Azure home-lab build agents
+
+Azure Pipelines uses three physical home-lab hosts. The Linux AMD64 host supports QEMU, VirtualBox, and VMware; the Windows AMD64 host supports Hyper-V, VirtualBox, and VMware; and the macOS ARM64 host supports VirtualBox and VMware. Each host runs only one provider-specific Azure agent service and one build at a time. Different agent names on the same physical host do not provide additional concurrency. One build may run concurrently on each physical host when their required providers and architectures differ.
+
+Provider changes require manual intervention: ask the user to stop the current agent service and start the required provider-specific service, then wait for confirmation before queueing. Do not change agent services or install host tools without explicit authorization.
+
+Queue builds against an exact branch and commit. For pipelines without runtime parameters, use `az pipelines build queue`. Because that command cannot supply YAML template parameters, parameterized builds must use the Build API:
+
+`az devops invoke --organization https://dev.azure.com/gusztavvargadr --area build --resource builds --route-parameters project=packer --api-version 7.1 --http-method POST --in-file <request.json>`
+
+The request must include `definition.id`, `sourceBranch`, `sourceVersion`, and any `templateParameters`. Before queueing, check both `inProgress` and `notStarted` builds for the physical host. Run ordered build sequences serially and queue the next build only after the previous build succeeded with a clean timeline. Windows image builds may take more than 90 minutes; duration alone is not a reason to cancel them. Stop automation on any failure or user request. Stopping a polling controller does not cancel an already-running Azure build.
+
 ## Commit & Pull Request Guidelines
 
 Recent commits use short, imperative, title-cased summaries such as `Update for 2607 - Core (#519)`. Keep each commit focused and include the PR number when merged. Pull requests should describe affected samples, images, providers, and build stages; link relevant issues; report commands or pipeline jobs run; and include screenshots only for documentation or visible guest-image changes.

--- a/src/windows/chef/cookbooks/gusztavvargadr_packer_windows/recipes/initialize.rb
+++ b/src/windows/chef/cookbooks/gusztavvargadr_packer_windows/recipes/initialize.rb
@@ -19,6 +19,125 @@ registry_key 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\
   action :create
 end
 
+powershell_script 'Configure and validate power policy' do
+  code <<-EOH
+    function Invoke-PowerCfg {
+      param([string[]] $PowerArguments)
+
+      $output = & powercfg.exe @PowerArguments 2>&1
+      if ($LASTEXITCODE -ne 0) {
+        throw "powercfg $($PowerArguments -join ' ') failed with exit code $($LASTEXITCODE): $($output -join ' ')"
+      }
+
+      return $output
+    }
+
+    Add-Type @'
+    using System;
+    using System.Runtime.InteropServices;
+
+    public static class PowerPolicyNativeMethods
+    {
+        [DllImport("powrprof.dll")]
+        public static extern UInt32 PowerGetActiveScheme(IntPtr userRootPowerKey, out IntPtr activePolicyGuid);
+
+        [DllImport("powrprof.dll")]
+        public static extern UInt32 PowerReadACValueIndex(IntPtr rootPowerKey, ref Guid schemeGuid,
+            ref Guid subgroupGuid, ref Guid settingGuid, out UInt32 valueIndex);
+
+        [DllImport("powrprof.dll")]
+        public static extern UInt32 PowerReadDCValueIndex(IntPtr rootPowerKey, ref Guid schemeGuid,
+            ref Guid subgroupGuid, ref Guid settingGuid, out UInt32 valueIndex);
+
+        [DllImport("kernel32.dll")]
+        public static extern IntPtr LocalFree(IntPtr memory);
+    }
+'@
+
+    function Get-ActivePowerScheme {
+      $schemePointer = [IntPtr]::Zero
+      $result = [PowerPolicyNativeMethods]::PowerGetActiveScheme([IntPtr]::Zero, [ref] $schemePointer)
+      if ($result -ne 0) {
+        throw "Unable to read the active power scheme (error code $result)."
+      }
+
+      try {
+        return [Guid] [Runtime.InteropServices.Marshal]::PtrToStructure($schemePointer, [type] [Guid])
+      } finally {
+        [void] [PowerPolicyNativeMethods]::LocalFree($schemePointer)
+      }
+    }
+
+    function Get-PowerSettingValue {
+      param(
+        [Guid] $Scheme,
+        [Guid] $Subgroup,
+        [Guid] $Setting,
+        [ValidateSet('AC', 'DC')] [string] $PowerSource
+      )
+
+      [UInt32] $value = 0
+      if ($PowerSource -eq 'AC') {
+        $result = [PowerPolicyNativeMethods]::PowerReadACValueIndex(
+          [IntPtr]::Zero, [ref] $Scheme, [ref] $Subgroup, [ref] $Setting, [ref] $value
+        )
+      } else {
+        $result = [PowerPolicyNativeMethods]::PowerReadDCValueIndex(
+          [IntPtr]::Zero, [ref] $Scheme, [ref] $Subgroup, [ref] $Setting, [ref] $value
+        )
+      }
+
+      if ($result -ne 0) {
+        throw "Unable to read the $PowerSource power setting '$Setting' (error code $result)."
+      }
+
+      return $value
+    }
+
+    $highPerformanceScheme = [Guid] '8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c'
+    $sleepSubgroup = [Guid] '238c9fa8-0aad-41ed-83f4-97be242c8f20'
+    $sleepTimeout = [Guid] '29f6c1db-86da-48c5-9fdb-f2b67b1f44da'
+    $hibernateTimeout = [Guid] '9d7815a6-7ee4-497e-8888-515a05f02364'
+
+    $availableSchemes = Invoke-PowerCfg @('/list')
+    if (($availableSchemes -join "`n") -notmatch $highPerformanceScheme) {
+      throw "High performance power scheme '$highPerformanceScheme' is unavailable."
+    }
+
+    Invoke-PowerCfg @('/setactive', $highPerformanceScheme) | Out-Null
+    Invoke-PowerCfg @('/setacvalueindex', $highPerformanceScheme, $sleepSubgroup, $sleepTimeout, 0) | Out-Null
+    Invoke-PowerCfg @('/setdcvalueindex', $highPerformanceScheme, $sleepSubgroup, $sleepTimeout, 0) | Out-Null
+    Invoke-PowerCfg @('/setacvalueindex', $highPerformanceScheme, $sleepSubgroup, $hibernateTimeout, 0) | Out-Null
+    Invoke-PowerCfg @('/setdcvalueindex', $highPerformanceScheme, $sleepSubgroup, $hibernateTimeout, 0) | Out-Null
+    Invoke-PowerCfg @('/setactive', $highPerformanceScheme) | Out-Null
+
+    $activeScheme = Get-ActivePowerScheme
+    if ($activeScheme -ne $highPerformanceScheme) {
+      throw "Power policy validation failed: active scheme is '$activeScheme'; expected High performance '$highPerformanceScheme'."
+    }
+
+    $sleepAc = Get-PowerSettingValue $activeScheme $sleepSubgroup $sleepTimeout 'AC'
+    $sleepDc = Get-PowerSettingValue $activeScheme $sleepSubgroup $sleepTimeout 'DC'
+    $hibernateAc = Get-PowerSettingValue $activeScheme $sleepSubgroup $hibernateTimeout 'AC'
+    $hibernateDc = Get-PowerSettingValue $activeScheme $sleepSubgroup $hibernateTimeout 'DC'
+
+    $timeouts = [ordered] @{
+      'sleep-ac' = $sleepAc
+      'sleep-dc' = $sleepDc
+      'hibernate-ac' = $hibernateAc
+      'hibernate-dc' = $hibernateDc
+    }
+    $invalidTimeouts = @($timeouts.GetEnumerator() | Where-Object { $_.Value -ne 0 })
+    if ($invalidTimeouts.Count -ne 0) {
+      $details = $invalidTimeouts | ForEach-Object { "$($_.Key)=$($_.Value)" }
+      throw "Power policy validation failed: $($details -join ', '); expected every timeout to be 0 (Never)."
+    }
+
+    Write-Output "Power policy: scheme=High performance ($activeScheme); sleep-ac=$sleepAc; sleep-dc=$sleepDc; hibernate-ac=$hibernateAc; hibernate-dc=$hibernateDc"
+  EOH
+  action :run
+end
+
 gusztavvargadr_windows_update '' do
   action :initialize
 end


### PR DESCRIPTION
## Summary

- Configure every Windows image through the shared Chef initialization path to activate the built-in High performance scheme before Windows Update begins.
- Set and validate AC/DC sleep and hibernation timeouts as numeric zero values, fail clearly on mismatches, and emit a concise build-log diagnostic.
- Add repository agent guidance for transcript-heavy builds and Azure home-lab build coordination.

## Why

Windows builds currently inherit provider-visible power defaults. A Balanced policy with an automatic sleep timeout can suspend a healthy unattended build during a long Windows Update operation.

## Validation

- `ruby -c src/windows/chef/cookbooks/gusztavvargadr_packer_windows/recipes/initialize.rb`
- `packer fmt -check src`
- `git diff --check`
- `dotnet cake --configuration windows-11/25h2-enterprise/qemu/native --target restore`
- Manual host-backed verification on Linux/QEMU, with additional Windows/VMware coverage (#558)
- Sysprep confirmed to preserve the configured power settings (#558)
- Two-axis code review: no Standards or Spec implementation findings

Closes #556